### PR TITLE
docs: require ASD-STE100 in all audit-generated prose

### DIFF
--- a/agents/lens-ai-security.md
+++ b/agents/lens-ai-security.md
@@ -106,6 +106,31 @@ rejected in `.readiness-audit/deferred.md` with its trigger.
 Provider-side controls you cannot see - rate limits configured in the vendor
 console, spend caps - are `UNVERIFIED` with a `resolve` field.
 
+## Language - write in ASD-STE100
+
+Write every prose field, and every line you report back, in ASD-STE100
+(Simplified Technical English). The goal is a report a tired reader
+understands on the first pass, in a second language if necessary.
+
+- One idea per sentence. Keep sentences to 20 words or fewer for descriptive
+  text, and 25 words or fewer for instructions.
+- Use the active voice. Name who does the thing: "An attacker reads the orders",
+  not "The orders can be read".
+- Use one word for one meaning. Do not call the same thing a "job", a "task" and
+  a "worker" in three sentences.
+- Use simple verbs and simple tenses. Prefer "the service stops" to "the service
+  would end up being terminated".
+- Do not use noun clusters of more than three words. Break
+  "customer order export retry queue" into a phrase with a preposition.
+- Do not drop articles. Write "the request", not "request".
+- Do not use metaphor, idiom, humour, or hedging ("arguably", "somewhat",
+  "a bit of a"). State the fact or mark it UNVERIFIED.
+- Keep code, identifiers, error strings, file paths, and severity labels exactly
+  as they are. ASD-STE100 applies to the prose around them, not to them.
+
+This applies hardest to `impact`, which a non-engineer reads, and to
+`recommendation`, which someone follows as an instruction.
+
 ## Output
 
 Write `.readiness-audit/findings/ai-security.json` in the documented JSON shape, IDs `PRA-AI-001`

--- a/agents/lens-backend.md
+++ b/agents/lens-backend.md
@@ -112,6 +112,31 @@ would resolve it. Resist stating that something has no timeout when what you
 actually know is that no timeout appears in the code you read; if a client
 default might supply one, that is UNVERIFIED with a note about which client.
 
+## Language - write in ASD-STE100
+
+Write every prose field, and every line you report back, in ASD-STE100
+(Simplified Technical English). The goal is a report a tired reader
+understands on the first pass, in a second language if necessary.
+
+- One idea per sentence. Keep sentences to 20 words or fewer for descriptive
+  text, and 25 words or fewer for instructions.
+- Use the active voice. Name who does the thing: "An attacker reads the orders",
+  not "The orders can be read".
+- Use one word for one meaning. Do not call the same thing a "job", a "task" and
+  a "worker" in three sentences.
+- Use simple verbs and simple tenses. Prefer "the service stops" to "the service
+  would end up being terminated".
+- Do not use noun clusters of more than three words. Break
+  "customer order export retry queue" into a phrase with a preposition.
+- Do not drop articles. Write "the request", not "request".
+- Do not use metaphor, idiom, humour, or hedging ("arguably", "somewhat",
+  "a bit of a"). State the fact or mark it UNVERIFIED.
+- Keep code, identifiers, error strings, file paths, and severity labels exactly
+  as they are. ASD-STE100 applies to the prose around them, not to them.
+
+This applies hardest to `impact`, which a non-engineer reads, and to
+`recommendation`, which someone follows as an instruction.
+
 ## Output
 
 Write `.readiness-audit/findings/backend.json` in the documented JSON shape, IDs `PRA-BE-001` upward.

--- a/agents/lens-database.md
+++ b/agents/lens-database.md
@@ -115,6 +115,31 @@ applies. Write those as risks with a precise `resolve` field - "the managed
 database's backup and PITR settings, and any record of a restore test" - never
 as established absence.
 
+## Language - write in ASD-STE100
+
+Write every prose field, and every line you report back, in ASD-STE100
+(Simplified Technical English). The goal is a report a tired reader
+understands on the first pass, in a second language if necessary.
+
+- One idea per sentence. Keep sentences to 20 words or fewer for descriptive
+  text, and 25 words or fewer for instructions.
+- Use the active voice. Name who does the thing: "An attacker reads the orders",
+  not "The orders can be read".
+- Use one word for one meaning. Do not call the same thing a "job", a "task" and
+  a "worker" in three sentences.
+- Use simple verbs and simple tenses. Prefer "the service stops" to "the service
+  would end up being terminated".
+- Do not use noun clusters of more than three words. Break
+  "customer order export retry queue" into a phrase with a preposition.
+- Do not drop articles. Write "the request", not "request".
+- Do not use metaphor, idiom, humour, or hedging ("arguably", "somewhat",
+  "a bit of a"). State the fact or mark it UNVERIFIED.
+- Keep code, identifiers, error strings, file paths, and severity labels exactly
+  as they are. ASD-STE100 applies to the prose around them, not to them.
+
+This applies hardest to `impact`, which a non-engineer reads, and to
+`recommendation`, which someone follows as an instruction.
+
 ## Output
 
 Write `.readiness-audit/findings/database.json` in the documented JSON shape, IDs `PRA-DB-001`

--- a/agents/lens-devops.md
+++ b/agents/lens-devops.md
@@ -100,6 +100,31 @@ repository", "a screenshot of the alert routing" - because those requests are
 themselves the first week of remediation. Never write "there is no monitoring"
 when what you know is that no monitoring appears in this repository.
 
+## Language - write in ASD-STE100
+
+Write every prose field, and every line you report back, in ASD-STE100
+(Simplified Technical English). The goal is a report a tired reader
+understands on the first pass, in a second language if necessary.
+
+- One idea per sentence. Keep sentences to 20 words or fewer for descriptive
+  text, and 25 words or fewer for instructions.
+- Use the active voice. Name who does the thing: "An attacker reads the orders",
+  not "The orders can be read".
+- Use one word for one meaning. Do not call the same thing a "job", a "task" and
+  a "worker" in three sentences.
+- Use simple verbs and simple tenses. Prefer "the service stops" to "the service
+  would end up being terminated".
+- Do not use noun clusters of more than three words. Break
+  "customer order export retry queue" into a phrase with a preposition.
+- Do not drop articles. Write "the request", not "request".
+- Do not use metaphor, idiom, humour, or hedging ("arguably", "somewhat",
+  "a bit of a"). State the fact or mark it UNVERIFIED.
+- Keep code, identifiers, error strings, file paths, and severity labels exactly
+  as they are. ASD-STE100 applies to the prose around them, not to them.
+
+This applies hardest to `impact`, which a non-engineer reads, and to
+`recommendation`, which someone follows as an instruction.
+
 ## Output
 
 Write `.readiness-audit/findings/devops.json` in the documented JSON shape, IDs `PRA-OPS-001` upward.

--- a/agents/lens-frontend.md
+++ b/agents/lens-frontend.md
@@ -95,6 +95,31 @@ behaviour, actual render performance, whether a screen reader can complete the
 signup flow - cannot be determined from source. That is `UNVERIFIED` with a
 `resolve` field, not a guess dressed up as a finding.
 
+## Language - write in ASD-STE100
+
+Write every prose field, and every line you report back, in ASD-STE100
+(Simplified Technical English). The goal is a report a tired reader
+understands on the first pass, in a second language if necessary.
+
+- One idea per sentence. Keep sentences to 20 words or fewer for descriptive
+  text, and 25 words or fewer for instructions.
+- Use the active voice. Name who does the thing: "An attacker reads the orders",
+  not "The orders can be read".
+- Use one word for one meaning. Do not call the same thing a "job", a "task" and
+  a "worker" in three sentences.
+- Use simple verbs and simple tenses. Prefer "the service stops" to "the service
+  would end up being terminated".
+- Do not use noun clusters of more than three words. Break
+  "customer order export retry queue" into a phrase with a preposition.
+- Do not drop articles. Write "the request", not "request".
+- Do not use metaphor, idiom, humour, or hedging ("arguably", "somewhat",
+  "a bit of a"). State the fact or mark it UNVERIFIED.
+- Keep code, identifiers, error strings, file paths, and severity labels exactly
+  as they are. ASD-STE100 applies to the prose around them, not to them.
+
+This applies hardest to `impact`, which a non-engineer reads, and to
+`recommendation`, which someone follows as an instruction.
+
 ## Output
 
 Write `.readiness-audit/findings/frontend.json` in the documented JSON shape, IDs `PRA-FE-001`

--- a/agents/lens-qa.md
+++ b/agents/lens-qa.md
@@ -94,6 +94,31 @@ tests found in reviewed scope". Whether the suite passes, how long it takes, and
 what the real coverage percentage is are all `UNVERIFIED` unless a report is
 checked in - say so rather than estimating.
 
+## Language - write in ASD-STE100
+
+Write every prose field, and every line you report back, in ASD-STE100
+(Simplified Technical English). The goal is a report a tired reader
+understands on the first pass, in a second language if necessary.
+
+- One idea per sentence. Keep sentences to 20 words or fewer for descriptive
+  text, and 25 words or fewer for instructions.
+- Use the active voice. Name who does the thing: "An attacker reads the orders",
+  not "The orders can be read".
+- Use one word for one meaning. Do not call the same thing a "job", a "task" and
+  a "worker" in three sentences.
+- Use simple verbs and simple tenses. Prefer "the service stops" to "the service
+  would end up being terminated".
+- Do not use noun clusters of more than three words. Break
+  "customer order export retry queue" into a phrase with a preposition.
+- Do not drop articles. Write "the request", not "request".
+- Do not use metaphor, idiom, humour, or hedging ("arguably", "somewhat",
+  "a bit of a"). State the fact or mark it UNVERIFIED.
+- Keep code, identifiers, error strings, file paths, and severity labels exactly
+  as they are. ASD-STE100 applies to the prose around them, not to them.
+
+This applies hardest to `impact`, which a non-engineer reads, and to
+`recommendation`, which someone follows as an instruction.
+
 ## Output
 
 Write `.readiness-audit/findings/qa.json` in the documented JSON shape, IDs `PRA-QA-001` upward.

--- a/agents/lens-security.md
+++ b/agents/lens-security.md
@@ -105,6 +105,31 @@ validation (tag frontend), and secrets handling in application code. DevOps owns
 secrets in CI. AI security owns tool calls driven by model output, though flag
 it to them if you spot one. QA owns PII in test fixtures.
 
+## Language - write in ASD-STE100
+
+Write every prose field, and every line you report back, in ASD-STE100
+(Simplified Technical English). The goal is a report a tired reader
+understands on the first pass, in a second language if necessary.
+
+- One idea per sentence. Keep sentences to 20 words or fewer for descriptive
+  text, and 25 words or fewer for instructions.
+- Use the active voice. Name who does the thing: "An attacker reads the orders",
+  not "The orders can be read".
+- Use one word for one meaning. Do not call the same thing a "job", a "task" and
+  a "worker" in three sentences.
+- Use simple verbs and simple tenses. Prefer "the service stops" to "the service
+  would end up being terminated".
+- Do not use noun clusters of more than three words. Break
+  "customer order export retry queue" into a phrase with a preposition.
+- Do not drop articles. Write "the request", not "request".
+- Do not use metaphor, idiom, humour, or hedging ("arguably", "somewhat",
+  "a bit of a"). State the fact or mark it UNVERIFIED.
+- Keep code, identifiers, error strings, file paths, and severity labels exactly
+  as they are. ASD-STE100 applies to the prose around them, not to them.
+
+This applies hardest to `impact`, which a non-engineer reads, and to
+`recommendation`, which someone follows as an instruction.
+
 ## Output
 
 Write `.readiness-audit/findings/security.json` in the documented JSON shape,

--- a/skills/production-readiness-audit/references/finding-format.md
+++ b/skills/production-readiness-audit/references/finding-format.md
@@ -78,6 +78,31 @@ For a `NOT_FOUND` or `UNVERIFIED` finding, `impact` describes what the missing
 control would have protected against, phrased as exposure rather than fact:
 "Nothing found that would restore this data after a bad deploy."
 
+## Language - write in ASD-STE100
+
+Write every prose field, in ASD-STE100
+(Simplified Technical English). The goal is a report a tired reader
+understands on the first pass, in a second language if necessary.
+
+- One idea per sentence. Keep sentences to 20 words or fewer for descriptive
+  text, and 25 words or fewer for instructions.
+- Use the active voice. Name who does the thing: "An attacker reads the orders",
+  not "The orders can be read".
+- Use one word for one meaning. Do not call the same thing a "job", a "task" and
+  a "worker" in three sentences.
+- Use simple verbs and simple tenses. Prefer "the service stops" to "the service
+  would end up being terminated".
+- Do not use noun clusters of more than three words. Break
+  "customer order export retry queue" into a phrase with a preposition.
+- Do not drop articles. Write "the request", not "request".
+- Do not use metaphor, idiom, humour, or hedging ("arguably", "somewhat",
+  "a bit of a"). State the fact or mark it UNVERIFIED.
+- Keep code, identifiers, error strings, file paths, and severity labels exactly
+  as they are. ASD-STE100 applies to the prose around them, not to them.
+
+This applies hardest to `impact`, which a non-engineer reads, and to
+`recommendation`, which someone follows as an instruction.
+
 ## Evidence states
 
 The distinction between these three is the single thing this audit is built to

--- a/skills/production-readiness-audit/references/report-writing.md
+++ b/skills/production-readiness-audit/references/report-writing.md
@@ -6,6 +6,22 @@ register, and the evidence-to-obtain list. It leaves `<!-- FILL: ... -->`
 markers where judgement is required. Replace every one of them. A report shipped
 with FILL markers still in it tells the reader the audit was abandoned halfway.
 
+## Language - write in ASD-STE100
+
+Write every section you fill in ASD-STE100 (Simplified Technical English). The
+reader may be tired, non-technical, or reading in a second language, and the
+verdict must survive all three.
+
+- One idea per sentence. 20 words or fewer for descriptive text, 25 or fewer for
+  instructions.
+- Active voice, with the actor named.
+- One word for one meaning across the whole report.
+- Simple verbs and simple tenses.
+- No noun cluster longer than three words. Keep the articles.
+- No metaphor, no idiom, no humour, no hedging. State the fact, or mark it
+  UNVERIFIED.
+- Code, identifiers, paths, error strings, and severity labels stay verbatim.
+
 ## Section B - the verdict
 
 Three sentences of context, then the call. A CTO reads this and nothing else


### PR DESCRIPTION
## The problem

The audit's output is written for people who did not write the code. A CTO reads Section B and decides go/no-go. A QA lead triages the P1 list. An engineer in another timezone reads the whole thing in a second language, on a Friday, after an incident.

Seven lens agents produce that output, and until now each one wrote in its own voice. Nothing in the prompts said how to write, only what to write. The failure modes that follow are the ordinary ones:

- **Same thing, three names.** One report calls a unit of work a "job" in the backend findings, a "task" in the DevOps findings, and a "worker" in the QA findings. The reader cannot tell whether that is one gap or three.
- **Hedged severity.** "This is arguably somewhat risky at scale" is a P0 written so nobody has to defend it. The evidence states (CONFIRMED / NOT_FOUND / UNVERIFIED) exist precisely so uncertainty is declared in a field, not smuggled into an adverb.
- **Noun stacks.** "customer order export retry queue failure" parses on the third read. There is no reason a reader should need three.
- **Passive voice with no actor.** "The orders can be read" hides the single most important fact in an authorization finding: by whom.
- **Long compound sentences.** A finding whose `impact` runs 60 words is a finding the dashboard renders and nobody finishes.

`impact` is the field this hurts most. It is the only line a non-engineer reads, and the existing format doc already spent a section arguing it must avoid file and class names. That was half the instruction. It said what not to put in; it did not say how to write the sentence.

## What this changes

Adds an explicit ASD-STE100 (Simplified Technical English) contract to every place the audit generates prose. ASD-STE100 is the aerospace maintenance-documentation standard, designed for exactly this reader: technical, tired, possibly non-native, and acting on what they read.

**`agents/lens-*.md` (all seven)** — a `## Language - write in ASD-STE100` section immediately before each agent's `## Output` section. Placed there so it governs both the JSON the agent writes and the summary lines it reports back to the orchestrator.

**`skills/production-readiness-audit/references/finding-format.md`** — the same rules applied to the JSON prose fields, positioned after the existing "Writing `impact`" guidance and before "Evidence states". Names `impact` and `recommendation` as the two fields where it matters most: one is read by a non-engineer, the other is followed as an instruction.

**`skills/production-readiness-audit/references/report-writing.md`** — a condensed version for the Stage 5 sections a human fills by hand, placed before "Section B - the verdict".

## The rules

| Rule | Instead of | Write |
| --- | --- | --- |
| One idea per sentence; ≤20 words descriptive, ≤25 instructions | "The endpoint accepts a tenant ID from the body, which, combined with the absence of a scope check, means any authenticated caller can reach other tenants' rows." | "The endpoint reads the tenant ID from the request body. No check confirms the caller owns that tenant." |
| Active voice, actor named | "The orders can be read." | "Any logged-in customer can read another company's orders." |
| One word for one meaning | job / task / worker for the same thing | pick one, use it throughout |
| Simple verbs and tenses | "would end up being terminated" | "stops" |
| No noun cluster over three words | "customer order export retry queue" | "the retry queue for customer order exports" |
| Keep the articles | "request fails validation" | "the request fails validation" |
| No metaphor, idiom, humour, or hedging | "arguably somewhat risky" | state the fact, or mark it UNVERIFIED |

Explicitly out of scope for the rewrite: code, identifiers, error strings, file paths, and severity labels. Those stay verbatim. The standard applies to the prose around them.

## Why a standard rather than "write clearly"

"Write clearly" is not checkable and does not survive seven independent agents. ASD-STE100 gives a word limit, a voice, and a one-word-one-meaning rule an agent can actually follow, and a reviewer can actually hold a finding against. It also makes findings comparable: two lenses describing similar exposure now produce sentences that look alike, which is what makes the deduplication step in Stage 4 meaningful.

## Testing

- All 27 tests pass (`PYTHONPATH=. python3 -m pytest tests -q`).
- Documentation and prompt text only. No code paths touched, no schema change, no dashboard change.

## Note for reviewers

The three inserted blocks are near-identical by design — each agent runs in its own context and reads only its own file, so the rules have to be present in each rather than referenced from one place. The `report-writing.md` copy is shortened because a human reads it, not an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
