### PR TITLE
Fix UTF-8 encoding for audit artifacts

### DIFF
--- a/scripts/absence_probe.py
+++ b/scripts/absence_probe.py
@@ -82,7 +82,7 @@ def collect(root: Path):
         try:
             if p.stat().st_size > MAX_FILE_BYTES:
                 continue
-            text = p.read_text(errors="replace")
+            text = p.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
         rel = p.relative_to(root).as_posix()
@@ -621,9 +621,11 @@ def main():
 
     outdir = Path(args.out) if args.out else root / ".readiness-audit" / "evidence"
     outdir.mkdir(parents=True, exist_ok=True)
-    (outdir / "absence-ledger.json").write_text(json.dumps(ledger, indent=2) + "\n")
+    (outdir / "absence-ledger.json").write_text(
+        json.dumps(ledger, indent=2) + "\n", encoding="utf-8"
+    )
     if not args.json_only:
-        (outdir / "absence-ledger.md").write_text(render_md(ledger))
+        (outdir / "absence-ledger.md").write_text(render_md(ledger), encoding="utf-8")
 
     absent = [r["id"] for r in results.values()
               if r["polarity"] == "control" and r["supports_state"] == "NOT_FOUND"]

--- a/scripts/assemble_report.py
+++ b/scripts/assemble_report.py
@@ -116,12 +116,12 @@ def main():
     lpath = d / "evidence" / "absence-ledger.json"
     ledger_meta = {}
     if lpath.exists():
-        raw = json.loads(lpath.read_text())
+        raw = json.loads(lpath.read_text(encoding="utf-8"))
         ledger = raw.get("controls", {})
         ledger_meta = {k: v for k, v in raw.items() if k != "controls"}
 
     state_file = d / "state.json"
-    state = json.loads(state_file.read_text()) if state_file.exists() else {}
+    state = json.loads(state_file.read_text(encoding="utf-8")) if state_file.exists() else {}
 
     def sev(fd):
         return fd["fields"].get("severity", "").strip().upper()
@@ -149,7 +149,7 @@ def main():
         p = d / name
         A(f"### {heading}")
         A("")
-        A(p.read_text().strip() if p.exists()
+        A(p.read_text(encoding="utf-8").strip() if p.exists()
           else f"<!-- FILL: {name} was not written; state the assumptions here -->")
         A("")
     if state.get("lenses_skipped"):
@@ -232,7 +232,7 @@ def main():
     A("## Section F - Deferred Controls")
     A("")
     dfile = d / "deferred.md"
-    A(dfile.read_text().strip() if dfile.exists()
+    A(dfile.read_text(encoding="utf-8").strip() if dfile.exists()
       else "<!-- FILL: controls considered and judged not yet necessary, each with the "
            "concrete trigger that should revisit it (\"needed when: >5k users / "
            "internet-facing / PCI scope\"). Also name controls deliberately deemed "
@@ -334,7 +334,7 @@ def main():
 
     report = "\n".join(out)
     (d).mkdir(parents=True, exist_ok=True)
-    (d / "report.md").write_text(report)
+    (d / "report.md").write_text(report, encoding="utf-8")
     # report.json is what the dashboard reads. Writing it here keeps the two
     # renderings of the same audit from ever drifting apart.
     report_json = write_report(root)

--- a/scripts/audit_state.py
+++ b/scripts/audit_state.py
@@ -61,7 +61,7 @@ def _load(root: Path):
     if not p.exists():
         return None
     try:
-        return json.loads(p.read_text())
+        return json.loads(p.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         return None
 
@@ -69,7 +69,7 @@ def _load(root: Path):
 def _save(root: Path, state):
     _dir(root).mkdir(parents=True, exist_ok=True)
     state["updated_at"] = _now()
-    _file(root).write_text(json.dumps(state, indent=2) + "\n")
+    _file(root).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
 def cmd_init(root: Path, execution_mode: str):

--- a/scripts/evidence_scan.py
+++ b/scripts/evidence_scan.py
@@ -68,7 +68,7 @@ def read(p: Path, limit=1_500_000):
     try:
         if p.stat().st_size > limit:
             return ""
-        return p.read_text(errors="replace")
+        return p.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
 
@@ -182,7 +182,9 @@ def main():
 
     outdir = Path(args.out) if args.out else root / ".readiness-audit" / "evidence"
     outdir.mkdir(parents=True, exist_ok=True)
-    (outdir / "inventory.json").write_text(json.dumps(inventory, indent=2) + "\n")
+    (outdir / "inventory.json").write_text(
+        json.dumps(inventory, indent=2) + "\n", encoding="utf-8"
+    )
 
     print(json.dumps({
         "total_files": total_files,

--- a/scripts/validate_findings.py
+++ b/scripts/validate_findings.py
@@ -107,7 +107,7 @@ def validate(root: Path):
     lpath = d / "evidence" / "absence-ledger.json"
     if lpath.exists():
         try:
-            ledger = json.loads(lpath.read_text()).get("controls", {})
+            ledger = json.loads(lpath.read_text(encoding="utf-8")).get("controls", {})
         except json.JSONDecodeError:
             errors.append(("absence-ledger.json", "-", "ledger is not valid JSON; re-run absence_probe.py"))
     else:

--- a/tests/test_utf8_file_io.py
+++ b/tests/test_utf8_file_io.py
@@ -1,0 +1,34 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AuditScriptEncodingTests(unittest.TestCase):
+    def test_audit_text_io_declares_utf8(self):
+        """Windows must not choose its system text encoding for audit files."""
+        missing = []
+
+        for path in sorted((ROOT / "scripts").glob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not isinstance(node.func, ast.Attribute):
+                    continue
+                if node.func.attr not in {"read_text", "write_text"}:
+                    continue
+                encoding = next(
+                    (keyword.value for keyword in node.keywords if keyword.arg == "encoding"),
+                    None,
+                )
+                if not isinstance(encoding, ast.Constant) or encoding.value != "utf-8":
+                    missing.append(f"{path.name}:{node.lineno}")
+
+        self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use explicit UTF-8 for audit artifact text I/O
- add a regression check for audit scripts

Closes #10

## Test
- python -m unittest discover -s tests -v