### PR TITLE
Run portable UTF-8 tests on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m unittest discover -s tests -v

--- a/tests/test_audit_state.py
+++ b/tests/test_audit_state.py
@@ -25,14 +25,14 @@ class AuditStateExecutionModeTests(unittest.TestCase):
         result, root = initialize()
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        state = json.loads((root / ".readiness-audit" / "state.json").read_text())
+        state = json.loads((root / ".readiness-audit" / "state.json").read_text(encoding="utf-8"))
         self.assertEqual(state["execution_mode"], "parallel")
 
     def test_init_persists_requested_sequential_execution(self):
         result, root = initialize("sequential")
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        state = json.loads((root / ".readiness-audit" / "state.json").read_text())
+        state = json.loads((root / ".readiness-audit" / "state.json").read_text(encoding="utf-8"))
         self.assertEqual(state["execution_mode"], "sequential")
 
 

--- a/tests/test_dashboard_skill_docs.py
+++ b/tests/test_dashboard_skill_docs.py
@@ -7,21 +7,21 @@ ROOT = Path(__file__).parents[1]
 
 class DashboardSkillDocumentationTests(unittest.TestCase):
     def test_manual_dashboard_skill_uses_python_loopback_server(self):
-        skill = (ROOT / "skills/production-readiness-dashboard/SKILL.md").read_text()
+        skill = (ROOT / "skills/production-readiness-dashboard/SKILL.md").read_text(encoding="utf-8")
         self.assertIn("/prod-readiness:production-readiness-dashboard", skill)
         self.assertIn("readiness_dashboard.py", skill)
         self.assertIn("127.0.0.1", skill)
         self.assertIn("read-only", skill.lower())
 
     def test_audit_starts_dashboard_without_changing_parallel_default(self):
-        audit_skill = (ROOT / "skills/production-readiness-audit/SKILL.md").read_text()
+        audit_skill = (ROOT / "skills/production-readiness-audit/SKILL.md").read_text(encoding="utf-8")
         self.assertIn("readiness_dashboard.py", audit_skill)
         self.assertIn("managed background Bash task", audit_skill)
         self.assertIn("Parallel is the default", audit_skill)
         self.assertIn("non-fatal", audit_skill)
 
     def test_readme_explains_automatic_and_manual_dashboard_use(self):
-        readme = (ROOT / "README.md").read_text()
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
         self.assertIn("production-readiness-dashboard", readme)
         self.assertIn("automatically", readme.lower())
         self.assertIn("127.0.0.1", readme)

--- a/tests/test_readiness_dashboard.py
+++ b/tests/test_readiness_dashboard.py
@@ -11,7 +11,7 @@ from scripts.readiness_dashboard import DASHBOARD_HTML, build_snapshot, create_s
 def write_findings(audit, lens, findings):
     (audit / "findings").mkdir(parents=True, exist_ok=True)
     (audit / "findings" / f"{lens}.json").write_text(
-        json.dumps({"schema": 1, "lens": lens, "findings": findings}))
+        json.dumps({"schema": 1, "lens": lens, "findings": findings}), encoding="utf-8")
 
 
 def finding(**overrides):
@@ -87,7 +87,7 @@ class SnapshotTests(unittest.TestCase):
         state = {"stage": "3-lenses", "stage_status": "in_progress",
                  "lenses_to_run": [], "lenses_skipped": {}}
         state.update(overrides)
-        (audit / "state.json").write_text(json.dumps(state))
+        (audit / "state.json").write_text(json.dumps(state), encoding="utf-8")
 
     def test_missing_audit_returns_unavailable_snapshot(self):
         snapshot = build_snapshot(Path(tempfile.mkdtemp()))
@@ -152,11 +152,11 @@ class SnapshotTests(unittest.TestCase):
         root = self._root()
         audit = root / ".readiness-audit"
         self._write_state(audit, stage_status="complete")
-        (audit / "report.md").write_text("## Executive Verdict\n\n**SHIP**\n")
+        (audit / "report.md").write_text("## Executive Verdict\n\n**SHIP**\n", encoding="utf-8")
         (audit / "verdict.json").write_text(json.dumps({
             "decision": "HOLD",
             "headline": "Two blockers make this unsafe to deploy.",
-        }))
+        }), encoding="utf-8")
 
         verdict = build_snapshot(root)["verdict"]
 
@@ -167,7 +167,9 @@ class SnapshotTests(unittest.TestCase):
         root = self._root()
         audit = root / ".readiness-audit"
         self._write_state(audit)
-        (audit / "verdict.json").write_text(json.dumps({"decision": "PROBABLY FINE"}))
+        (audit / "verdict.json").write_text(
+            json.dumps({"decision": "PROBABLY FINE"}), encoding="utf-8"
+        )
 
         snapshot = build_snapshot(root)
 
@@ -179,7 +181,7 @@ class SnapshotTests(unittest.TestCase):
         audit = root / ".readiness-audit"
         self._write_state(audit)
         write_findings(audit, "security", [finding()])
-        (audit / "findings" / "qa.json").write_text("{ not json")
+        (audit / "findings" / "qa.json").write_text("{ not json", encoding="utf-8")
 
         snapshot = build_snapshot(root)
 
@@ -202,7 +204,7 @@ class SnapshotTests(unittest.TestCase):
     def test_malformed_state_degrades_instead_of_raising(self):
         root = self._root()
         audit = root / ".readiness-audit"
-        (audit / "state.json").write_text("{ not json")
+        (audit / "state.json").write_text("{ not json", encoding="utf-8")
         write_findings(audit, "security", [finding()])
 
         snapshot = build_snapshot(root)
@@ -222,7 +224,7 @@ class SnapshotTests(unittest.TestCase):
                               "hit_count": 2, "supports_state": "NOT_FOUND",
                               "hits": [{"path": "infra/backup.tf"}, {"path": "README.md"}]},
             "a_branch_selector": {"polarity": "branch", "label": "ignored", "hit_count": 5},
-        }}))
+        }}), encoding="utf-8")
 
         rows = {row["id"]: row for row in build_snapshot(root)["evidence"]}
 

--- a/tests/test_test_suite_encoding.py
+++ b/tests/test_test_suite_encoding.py
@@ -1,0 +1,34 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestSuiteEncodingTests(unittest.TestCase):
+    def test_test_text_io_declares_utf8(self):
+        """Windows must not choose its system text encoding during tests."""
+        missing = []
+
+        for path in sorted((ROOT / "tests").glob("test_*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not isinstance(node.func, ast.Attribute):
+                    continue
+                if node.func.attr not in {"read_text", "write_text"}:
+                    continue
+                encoding = next(
+                    (keyword.value for keyword in node.keywords if keyword.arg == "encoding"),
+                    None,
+                )
+                if not isinstance(encoding, ast.Constant) or encoding.value != "utf-8":
+                    missing.append(f"{path.name}:{node.lineno}")
+
+        self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use explicit UTF-8 for all test file I/O
- add Windows to test CI
- add a regression check for test file I/O

Closes #11

## Test
- python -m unittest discover -s tests -v