### PR TITLE
Make the audit deterministic, and let people watch it and share it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,78 @@
+# Production Readiness Audit
+
+A Claude Code plugin that audits a local codebase from seven angles and produces
+an evidence-tagged go/no-go verdict, plus a local dashboard for watching the
+audit and exporting its results.
+
+## The audit
+
+**Lens**:
+One of the seven specialist perspectives (security, backend, frontend, devops,
+qa, database, ai-security) that evaluates the shared evidence body and authors
+findings. Also referred to as a *reviewer*, since each lens stands in for a
+senior engineer reviewing the system.
+_Avoid_: Agent, auditor, checker
+
+**Evidence pass**:
+The single scan of the repository, run once before any lens, whose output every
+lens consumes. A lens that rescans the repository has broken the design.
+_Avoid_: Scan phase, discovery
+
+**Absence ledger**:
+The record of every control that was searched for, the patterns used, the hit
+count, and whether zero hits should be reported as NOT_FOUND or UNVERIFIED.
+_Avoid_: Negative results, gap list
+
+**Evidence state**:
+One of CONFIRMED (proved, cites file:line), NOT_FOUND (searched for, cites a
+zero-hit ledger row), or UNVERIFIED (not visible from here). Every finding
+carries exactly one.
+_Avoid_: Status, confidence
+
+**Factors**:
+The closed enums a lens supplies for a finding — exposure, data class, blast
+radius, and compensating control — from which severity is derived. A lens
+supplies factors; it never supplies a severity.
+_Avoid_: Risk inputs, attributes
+
+**Derived severity**:
+The P0–P3 rating computed from a finding's factors by a fixed rubric. Never
+authored by a lens.
+_Avoid_: Priority, rating, score
+
+**Decision**:
+The computed go/no-go call — SHIP, FIX_THEN_SHIP, or HOLD — a pure function of
+the validated findings. Distinct from the *headline* and *summary*, which are
+prose a lens author writes.
+_Avoid_: Verdict (the verdict is the decision plus its prose), recommendation
+
+## The dashboard
+
+**Handshake file**:
+`.readiness-audit/dashboard.json`, written atomically by the dashboard server
+once it is listening, carrying the URL, port, PID, resolved audit root, and
+start time. It is a cache, not a source of truth — the running server is.
+_Avoid_: Lock file, state file, PID file
+
+**Heartbeat**:
+A single progress event a lens appends to its own progress log while it works,
+carrying a phase and an optional free-text note.
+_Avoid_: Progress update, log line, trace
+
+**Phase**:
+The stage of a lens's own work, drawn from a closed vocabulary: started,
+evidence-read, analyzing, writing-findings, done. Distinct from an audit
+*stage*, which describes the whole run.
+_Avoid_: Step, status
+
+**No signal**:
+How the dashboard renders a lens that has not emitted a heartbeat within the
+silence threshold. Never rendered as progress.
+_Avoid_: Stalled, unknown, idle
+
+**Export**:
+A derived, shareable document set generated from a snapshot of the audit —
+a combined report plus one per-lens report. Exports are written once and never
+overwritten.
+_Avoid_: Report (the report is an audit artifact; an export is a shareable
+rendering of it), download

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -30,7 +30,7 @@ Live progress plus a skimmable, markdown-rendered verdict — the thing a plain 
 - Zero external dependencies: implemented with Python's stdlib `http.server` (`ThreadingHTTPServer`/`BaseHTTPRequestHandler`) only — no Flask/FastAPI/etc.
 - Single-file delivery: the HTML/CSS/JS is an embedded string (`DASHBOARD_HTML`) inside `scripts/readiness_dashboard.py`, served as one response — no separate static asset pipeline.
 - No authentication (matches local-only, single-user trust model).
-- Read-only with respect to the audit: the dashboard displays state, it does not mutate audit data.
+- Read-only with respect to the audit: the dashboard displays state, it does not mutate audit data. Its one write is the export, which produces derived documents under `.readiness-audit/export/` and never touches audit state.
 - Views/nav: Overview and Findings tabs (per prior work — verify current tab set against code before assuming more exist).
 - Markdown rendering is used for findings, report, and evidence text.
 
@@ -39,5 +39,5 @@ Live progress plus a skimmable, markdown-rendered verdict — the thing a plain 
 1. Legible over exhaustive — surface stage/verdict at a glance before requiring drill-down.
 2. Zero-friction to run — no install step, no auth, no external service; must work the instant the audit starts.
 3. Local-only trust boundary is non-negotiable — never widen beyond `127.0.0.1` or add network egress.
-4. Read-only observer — the dashboard never becomes a control plane for the audit.
+4. Read-only observer — the dashboard never becomes a control plane for the audit. Exporting is the single, narrow exception: it writes derived documents for humans to share, it cannot start, stop, or alter an audit, and no other write is permitted.
 5. Built for a solo dev's terminal-adjacent workflow, not a hosted multi-user product.

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ each specialist's work one step at a time.
 
 ### Watch an audit in your browser (optional)
 
-After Claude successfully initializes a new audit or confirms a resume, it
-automatically starts a read-only dashboard in the background and continues the
-audit. The dashboard is local-only and listens on `127.0.0.1`; if it cannot
-start, the audit proceeds normally.
+When a new audit is initialized or a resume is confirmed, a read-only dashboard
+starts automatically and the audit continues. The dashboard is local-only and
+listens on `127.0.0.1`; if it cannot start, the audit proceeds normally and the
+reason is written to `.readiness-audit/dashboard.log`.
 
 To start it manually, run this in Claude Code:
 
@@ -105,9 +105,52 @@ To start it manually, run this in Claude Code:
 /prod-readiness:production-readiness-dashboard
 ```
 
-The dashboard prints an address such as `http://127.0.0.1:<port>/`. Open that
-URL if your browser does not open automatically. Press Ctrl-C to stop a
-manually launched dashboard.
+The dashboard prints an address such as `http://127.0.0.1:<port>/` and opens it
+in your browser where it can. Starting it again while it is already running
+reuses the same server rather than starting a second one.
+
+The server is detached, so it keeps serving the finished report after the Claude
+Code session ends and Ctrl-C does not reach it. It closes itself after an hour
+with no reader, or immediately with:
+
+```bash
+python3 scripts/readiness_dashboard.py <project-root> --stop
+```
+
+### Watch what each specialist is doing
+
+While the audit runs, every lens reports its own progress at five checkpoints:
+starting, reading evidence, analyzing, writing findings, and finished. The
+Overview shows each specialist's current phase and how long ago it reported,
+with an activity feed of what they said.
+
+A specialist that has reported nothing recently is shown as **no signal**. It is
+never shown as progress: a live view that invents activity is worse than one
+that admits it does not know.
+
+### Export a report to share
+
+The dashboard's **Export report** button, or:
+
+```bash
+python3 scripts/export_report.py <project-root>
+```
+
+writes a shareable document set to `.readiness-audit/export/<git-ref>-<time>/`:
+
+- `report.tex` — the full audit: verdict, context, scope, evidence summary, all
+  seven lens sections, and an appendix of everything that could not be verified.
+- `report-<lens>.tex` — one document per specialist, so a security engineer gets
+  a report without the frontend findings and the other way round.
+- `report.md` — the plain-markdown trail, for anyone without a TeX toolchain.
+- `report.pdf` — only when `tectonic` or `pdflatex` is installed. Without one,
+  the `.tex` files are still written and the command tells you how to compile
+  them.
+
+Each export gets its own directory and nothing is ever overwritten, so "which
+version did they read" always has an answer. Exporting a running audit is
+allowed; the front page then carries a banner naming the stage it reached and
+the lenses that have not reported yet.
 
 It opens on the decision, not the evidence: the verdict, how many findings block
 the release, and the handful that need attention first. Each finding leads with

--- a/agents/lens-ai-security.md
+++ b/agents/lens-ai-security.md
@@ -23,6 +23,15 @@ scope**, cite the probes you checked, and return. Do not invent risks for a
 system that has no model in it. A fabricated AI section is the fastest way to
 make a reader stop trusting the other six lenses.
 
+Report a heartbeat on this path too, before you return:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress.py" note <root> ai-security done "No model integration found in reviewed scope."
+```
+
+A lens that exits early and says nothing looks stalled to the person watching
+the dashboard.
+
 If there is signal, continue.
 
 ## Read before you look at any source
@@ -106,6 +115,28 @@ rejected in `.readiness-audit/deferred.md` with its trigger.
 Provider-side controls you cannot see - rate limits configured in the vendor
 console, spend caps - are `UNVERIFIED` with a `resolve` field.
 
+## Severity factors
+
+Set `exposure` from who can reach the model: `internet` for an unauthenticated
+endpoint, `authenticated` for one behind login, `internal` for an
+internal-only tool. `local` rarely applies.
+
+Set `data_class` from what the model can read or leak. Use `secrets` for
+credentials in the system prompt or context, and `pii` for personal data in
+context. Use `financial` where the model handles money, `business` for other
+proprietary data, and `none` for a pure availability or cost issue.
+
+Set `blast_radius` from what the model can do once compromised. Use `systemic`
+when a tool call runs under a service account that reaches every tenant's
+data, and `multi-tenant` when it can cross tenant boundaries some other way.
+Use `single-tenant` or `single-user` when the model acts only within the
+requesting user's own permissions.
+
+Set `compensating_control` to `present` only for a real gate on the
+consequential action - a human-in-the-loop approval, a scoped token. A system
+prompt instruction telling the model to behave does not count; a prompt
+injection defeats it by design.
+
 ## Language - write in ASD-STE100
 
 Write every prose field, and every line you report back, in ASD-STE100
@@ -132,6 +163,17 @@ This applies hardest to `impact`, which a non-engineer reads, and to
 `recommendation`, which someone follows as an instruction.
 
 ## Output
+
+Report your progress while you work. At each of five checkpoints, run:
+
+    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress.py" note <root> ai-security <phase> "<short note>"
+
+The five checkpoints, in order, are `started`, `evidence-read`, `analyzing`,
+`writing-findings`, and `done`. The note is one short, plain sentence about
+what you do right now - a person reads it on the dashboard. Extra notes
+between checkpoints are welcome; the five above are mandatory. A missing
+heartbeat shows as no signal on the dashboard, not as progress, so skipping
+one makes your run look stalled.
 
 Write `.readiness-audit/findings/ai-security.json` in the documented JSON shape, IDs `PRA-AI-001`
 

--- a/agents/lens-backend.md
+++ b/agents/lens-backend.md
@@ -112,6 +112,27 @@ would resolve it. Resist stating that something has no timeout when what you
 actually know is that no timeout appears in the code you read; if a client
 default might supply one, that is UNVERIFIED with a note about which client.
 
+## Severity factors
+
+Set `exposure` from who can trigger the failure: `internet` for a
+public-facing endpoint, `authenticated` for one that needs a session,
+`internal` for a service-to-service call behind the network boundary, `local`
+for background work with no external trigger.
+
+Set `data_class` from what a failure loses or corrupts: `financial` for
+payments, `pii` for personal data, `business` for orders, inventory, or other
+operational state, `none` for a failure with no data consequence.
+
+Set `blast_radius` from how far the failure spreads. Use `systemic` when a
+shared resource - a connection pool, a cache, a broker - fails for every
+tenant at once. Use `multi-tenant` when it crosses tenants without being
+system-wide, and `single-tenant` or `single-user` when it stays scoped to one
+caller.
+
+Set `compensating_control` to `present` only when a retry, timeout, circuit
+breaker, or fallback actually bounds the damage from this specific failure,
+not because one exists somewhere else in the system.
+
 ## Language - write in ASD-STE100
 
 Write every prose field, and every line you report back, in ASD-STE100
@@ -138,6 +159,17 @@ This applies hardest to `impact`, which a non-engineer reads, and to
 `recommendation`, which someone follows as an instruction.
 
 ## Output
+
+Report your progress while you work. At each of five checkpoints, run:
+
+    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress.py" note <root> backend <phase> "<short note>"
+
+The five checkpoints, in order, are `started`, `evidence-read`, `analyzing`,
+`writing-findings`, and `done`. The note is one short, plain sentence about
+what you do right now - a person reads it on the dashboard. Extra notes
+between checkpoints are welcome; the five above are mandatory. A missing
+heartbeat shows as no signal on the dashboard, not as progress, so skipping
+one makes your run look stalled.
 
 Write `.readiness-audit/findings/backend.json` in the documented JSON shape, IDs `PRA-BE-001` upward.
 

--- a/agents/lens-database.md
+++ b/agents/lens-database.md
@@ -115,6 +115,27 @@ applies. Write those as risks with a precise `resolve` field - "the managed
 database's backup and PITR settings, and any record of a restore test" - never
 as established absence.
 
+## Severity factors
+
+Set `exposure` from how the gap is reached, not from whether the database
+itself faces the internet. Use `authenticated` when application users trigger
+the loss through a bug or a bad write. Use `internal` when only an operator
+action - a migration, a restore - triggers it. Use `internet` only if the
+database is directly reachable. `local` rarely applies.
+
+Set `data_class` from what the affected rows contain: `secrets`, `pii`,
+`financial`, `business`, or `none`. Read the schema for the actual columns
+rather than assuming from the table name.
+
+Set `blast_radius` from what the gap threatens. Use `systemic` for anything
+that threatens the whole dataset - no PITR, no verified restore, a destructive
+migration with no expand-contract path. Use `multi-tenant` or `single-tenant`
+for a schema or query bug scoped to specific rows.
+
+Set `compensating_control` to `present` only for a control that actually
+bounds data loss for this specific gap. A nightly snapshot does not
+compensate for the absence of PITR when the stated RPO is one hour.
+
 ## Language - write in ASD-STE100
 
 Write every prose field, and every line you report back, in ASD-STE100
@@ -141,6 +162,17 @@ This applies hardest to `impact`, which a non-engineer reads, and to
 `recommendation`, which someone follows as an instruction.
 
 ## Output
+
+Report your progress while you work. At each of five checkpoints, run:
+
+    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress.py" note <root> database <phase> "<short note>"
+
+The five checkpoints, in order, are `started`, `evidence-read`, `analyzing`,
+`writing-findings`, and `done`. The note is one short, plain sentence about
+what you do right now - a person reads it on the dashboard. Extra notes
+between checkpoints are welcome; the five above are mandatory. A missing
+heartbeat shows as no signal on the dashboard, not as progress, so skipping
+one makes your run look stalled.
 
 Write `.readiness-audit/findings/database.json` in the documented JSON shape, IDs `PRA-DB-001`
 

--- a/agents/lens-devops.md
+++ b/agents/lens-devops.md
@@ -100,6 +100,27 @@ repository", "a screenshot of the alert routing" - because those requests are
 themselves the first week of remediation. Never write "there is no monitoring"
 when what you know is that no monitoring appears in this repository.
 
+## Severity factors
+
+Set `exposure` from who is affected when the gap bites. Use `internet` when it
+lets production traffic fail publicly, and `authenticated` for logged-in users
+only. Use `internal` for an operational gap - no IaC, no drift detection -
+that only your own team feels. `local` rarely applies.
+
+Set `data_class` from what is at risk. Use `secrets` for CI or config leaks,
+and `financial` or `pii` when the gap risks losing or exposing that data on
+restore or rollback. Use `business` for other operational data, and `none`
+for a pure availability gap with no data at stake.
+
+Set `blast_radius` from what a failure takes down. Use `systemic` for anything
+that fails for the whole system at once - bad migration sequencing, a broken
+rollback, no alerting. Use `multi-tenant` or narrower only when the gap is
+scoped to part of the fleet.
+
+Set `compensating_control` to `present` only for a control you can point to in
+this repo or in `context.md`. An untested rollback plan or an unmonitored
+dashboard is not a compensating control - it is the finding.
+
 ## Language - write in ASD-STE100
 
 Write every prose field, and every line you report back, in ASD-STE100
@@ -126,6 +147,17 @@ This applies hardest to `impact`, which a non-engineer reads, and to
 `recommendation`, which someone follows as an instruction.
 
 ## Output
+
+Report your progress while you work. At each of five checkpoints, run:
+
+    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress.py" note <root> devops <phase> "<short note>"
+
+The five checkpoints, in order, are `started`, `evidence-read`, `analyzing`,
+`writing-findings`, and `done`. The note is one short, plain sentence about
+what you do right now - a person reads it on the dashboard. Extra notes
+between checkpoints are welcome; the five above are mandatory. A missing
+heartbeat shows as no signal on the dashboard, not as progress, so skipping
+one makes your run look stalled.
 
 Write `.readiness-audit/findings/devops.json` in the documented JSON shape, IDs `PRA-OPS-001` upward.
 

--- a/agents/lens-frontend.md
+++ b/agents/lens-frontend.md
@@ -95,6 +95,26 @@ behaviour, actual render performance, whether a screen reader can complete the
 signup flow - cannot be determined from source. That is `UNVERIFIED` with a
 `resolve` field, not a guess dressed up as a finding.
 
+## Severity factors
+
+Set `exposure` from who reaches the affected surface: `internet` for a public
+page, `authenticated` for one behind login, `internal` for an admin panel
+gated by network or role, `local` only for a dev-only surface.
+
+Set `data_class` from what the gap exposes. Use `secrets` for tokens or API
+keys in the client, and `pii` for personal data rendered or stored in the
+browser. Use `financial` for payment data, `business` for other product data,
+and `none` for a pure UX defect with no data at stake.
+
+Set `blast_radius` almost always to `single-user` - most frontend defects sit
+inside one person's session. Use `multi-tenant` or `systemic` only when the
+bug itself leaks another account's data into the current session, or breaks
+the app for every user at once, such as a bundle that fails to load.
+
+Set `compensating_control` to `present` only when server-side validation or
+rendering already blocks the same failure. A client-only check never counts,
+since the server is the boundary that matters.
+
 ## Language - write in ASD-STE100
 
 Write every prose field, and every line you report back, in ASD-STE100
@@ -121,6 +141,17 @@ This applies hardest to `impact`, which a non-engineer reads, and to
 `recommendation`, which someone follows as an instruction.
 
 ## Output
+
+Report your progress while you work. At each of five checkpoints, run:
+
+    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress.py" note <root> frontend <phase> "<short note>"
+
+The five checkpoints, in order, are `started`, `evidence-read`, `analyzing`,
+`writing-findings`, and `done`. The note is one short, plain sentence about
+what you do right now - a person reads it on the dashboard. Extra notes
+between checkpoints are welcome; the five above are mandatory. A missing
+heartbeat shows as no signal on the dashboard, not as progress, so skipping
+one makes your run look stalled.
 
 Write `.readiness-audit/findings/frontend.json` in the documented JSON shape, IDs `PRA-FE-001`
 

--- a/agents/lens-qa.md
+++ b/agents/lens-qa.md
@@ -94,6 +94,23 @@ tests found in reviewed scope". Whether the suite passes, how long it takes, and
 what the real coverage percentage is are all `UNVERIFIED` unless a report is
 checked in - say so rather than estimating.
 
+## Severity factors
+
+A missing test has no exposure or data class of its own - it inherits the
+factors of the path it fails to cover. Rate a coverage gap by what would go
+wrong in production if that path breaks unnoticed, not by anything about the
+test suite itself.
+
+Set `exposure`, `data_class`, and `blast_radius` from the underlying flow. An
+uncovered payment path is `authenticated` or `internet`, `financial`, and
+whatever tenant scope the flow touches. An uncovered internal admin script
+scores lower on all three.
+
+Set `compensating_control` to `absent` for almost every finding here - the gap
+you report is the absence of the control. Use `present` only when a different
+test, manual process, or monitor would actually catch the regression before it
+reaches a user.
+
 ## Language - write in ASD-STE100
 
 Write every prose field, and every line you report back, in ASD-STE100
@@ -120,6 +137,17 @@ This applies hardest to `impact`, which a non-engineer reads, and to
 `recommendation`, which someone follows as an instruction.
 
 ## Output
+
+Report your progress while you work. At each of five checkpoints, run:
+
+    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress.py" note <root> qa <phase> "<short note>"
+
+The five checkpoints, in order, are `started`, `evidence-read`, `analyzing`,
+`writing-findings`, and `done`. The note is one short, plain sentence about
+what you do right now - a person reads it on the dashboard. Extra notes
+between checkpoints are welcome; the five above are mandatory. A missing
+heartbeat shows as no signal on the dashboard, not as progress, so skipping
+one makes your run look stalled.
 
 Write `.readiness-audit/findings/qa.json` in the documented JSON shape, IDs `PRA-QA-001` upward.
 

--- a/agents/lens-security.md
+++ b/agents/lens-security.md
@@ -105,6 +105,27 @@ validation (tag frontend), and secrets handling in application code. DevOps owns
 secrets in CI. AI security owns tool calls driven by model output, though flag
 it to them if you spot one. QA owns PII in test fixtures.
 
+## Severity factors
+
+Set `exposure` from where the request can originate: `internet` for an
+unauthenticated endpoint, `authenticated` for one that needs a valid session,
+`internal` for a VPN- or network-gated path, `local` for anything reachable
+only on the host itself.
+
+Set `data_class` from what the flaw exposes or lets an attacker change:
+`secrets` for keys and credentials, `pii` for personal data, `financial` for
+payment or billing data, `business` for other proprietary data, `none` for
+neither.
+
+Set `blast_radius` from who a single exploit reaches: `systemic` when it
+breaks an isolation guarantee for every tenant, `multi-tenant` when it crosses
+one tenant boundary, `single-tenant` when it stays inside one tenant,
+`single-user` when it touches one account.
+
+Set `compensating_control` to `present` only for a control that actually stops
+or contains this specific attack path. A WAF rule that does not cover this
+input, or an auth check on a different route, does not count.
+
 ## Language - write in ASD-STE100
 
 Write every prose field, and every line you report back, in ASD-STE100
@@ -131,6 +152,17 @@ This applies hardest to `impact`, which a non-engineer reads, and to
 `recommendation`, which someone follows as an instruction.
 
 ## Output
+
+Report your progress while you work. At each of five checkpoints, run:
+
+    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/progress.py" note <root> security <phase> "<short note>"
+
+The five checkpoints, in order, are `started`, `evidence-read`, `analyzing`,
+`writing-findings`, and `done`. The note is one short, plain sentence about
+what you do right now - a person reads it on the dashboard. Extra notes
+between checkpoints are welcome; the five above are mandatory. A missing
+heartbeat shows as no signal on the dashboard, not as progress, so skipping
+one makes your run look stalled.
 
 Write `.readiness-audit/findings/security.json` in the documented JSON shape,
 IDs `PRA-SEC-001` upward.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Routes production-readiness requests into the staged audit workflow.",
+  "description": "Routes production-readiness requests into the staged audit workflow and starts the dashboard when an audit begins.",
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -7,6 +7,17 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/route_readiness_prompt.py\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/launch_dashboard_hook.py\""
           }
         ]
       }

--- a/scripts/assemble_report.py
+++ b/scripts/assemble_report.py
@@ -22,8 +22,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from validate_findings import parse_file, validate, LENS_PREFIX  # noqa: E402
-from finding_store import load_verdict, write_report  # noqa: E402
+from validate_findings import parse_file, validate, derive_severity, LENS_PREFIX  # noqa: E402
+from finding_store import compute_decision, load_verdict, write_report  # noqa: E402
 
 DECISION_TEXT = {
     "SHIP": "SHIP",
@@ -62,6 +62,9 @@ def load_findings(root: Path):
             continue  # validate_findings.py reports this; the gate above blocks on it
         for fd in parsed:
             fd["lens_file"] = f.stem
+            # parse_file() no longer carries an authored severity - it is
+            # derived from factors, same as validate() derives it.
+            fd["fields"]["severity"] = derive_severity(fd)
             out.append(fd)
     return out
 
@@ -171,18 +174,33 @@ def main():
     verdict, verdict_errors = load_verdict(root)
     for message in verdict_errors:
         print(message, file=sys.stderr)
-    if verdict["decision"] or verdict["headline"]:
-        A(f"**{DECISION_TEXT.get(verdict['decision'], verdict['decision'] or 'VERDICT')}**")
-        A("")
+
+    # decision is computed from the findings, never taken on the model's
+    # say-so. validate_findings.py already blocks assembly (absent --force)
+    # if verdict.json asserted a decision that disagrees with this one, so
+    # reaching this line means either they agree or --force was passed.
+    computed_decision = compute_decision([{"severity": sev(f)} for f in findings])
+    if verdict["decision"] and verdict["decision"] != computed_decision:
+        print(
+            f"verdict.json declares decision {verdict['decision']!r} but the "
+            f"findings compute to {computed_decision!r}; using the computed "
+            "decision because --force was passed. Fix the findings or "
+            "verdict.json to clear this properly.",
+            file=sys.stderr,
+        )
+
+    A(f"**{DECISION_TEXT.get(computed_decision, computed_decision)}**")
+    A("")
+    if verdict["headline"] or verdict["summary"]:
         for paragraph in (verdict["headline"], verdict["summary"]):
             if paragraph:
                 A(paragraph)
                 A("")
     else:
-        A("<!-- FILL: write .readiness-audit/verdict.json with a decision of SHIP / "
-          "FIX_THEN_SHIP / HOLD, a headline, and a summary. State explicitly how much "
-          f"of the verdict rests on UNVERIFIED areas - there are {len(unverified)} "
-          "unverified findings. This section is generated from that file. -->")
+        A("<!-- FILL: write .readiness-audit/verdict.json with a headline and a "
+          "summary (no decision - that is computed above from the findings). "
+          "State explicitly how much of the verdict rests on UNVERIFIED areas - "
+          f"there are {len(unverified)} unverified findings. -->")
         A("")
 
     # ---- C / D ----

--- a/scripts/export_report.py
+++ b/scripts/export_report.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""
+export_report.py - build a shareable LaTeX report set from an audit snapshot.
+
+Everything this writes comes from `finding_store.build_report()` - the same
+function `readiness_dashboard.py` renders in the browser - so an export can
+never say something the dashboard does not also say. The evidence ledger
+summary is the one exception: it is read straight from
+`.readiness-audit/evidence/absence-ledger.json`, the same file the dashboard's
+Evidence tab reads, because that data does not live in `build_report()`.
+
+Each call writes a fresh, timestamped directory under
+`.readiness-audit/export/` and never touches an existing one. Nothing here
+mutates the audit trail; this is a read-only projection of it, same as the
+dashboard.
+
+A finding's file paths and code excerpts are attacker-relevant text. LaTeX
+treats a dozen ASCII characters as syntax, so every interpolated string goes
+through `latex_escape()` first - never stripped, always escaped, so a mangled
+document is never mistaken for a missing finding.
+
+Usage:
+    python3 export_report.py <project_root>
+"""
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from finding_store import LENS_LABEL, LENS_ORDER, build_report  # noqa: E402
+
+# --------------------------------------------------------------------------
+# LaTeX escaping - a correctness requirement, applied to every interpolated
+# string. Each character is looked up once against the original text, so the
+# backslashes this introduces are never re-scanned and re-escaped.
+# --------------------------------------------------------------------------
+
+_LATEX_SPECIAL = {
+    "\\": r"\textbackslash{}",
+    "{": r"\{",
+    "}": r"\}",
+    "$": r"\$",
+    "%": r"\%",
+    "&": r"\&",
+    "#": r"\#",
+    "_": r"\_",
+    "^": r"\textasciicircum{}",
+    "~": r"\textasciitilde{}",
+}
+
+
+def latex_escape(value) -> str:
+    """Escape one piece of interpolated text for safe use in a .tex document.
+
+    None and "" both become "". Every other value is stringified first, so
+    callers never need to coerce ids, counts, or enum values by hand.
+    """
+    if value is None:
+        return ""
+    return "".join(_LATEX_SPECIAL.get(ch, ch) for ch in str(value))
+
+
+def _verbatim_block(text: str) -> str:
+    """Wrap raw text (a code excerpt, a file:line reference) in a verbatim
+    environment instead of escaping it, per the requirement that code
+    snippets render as code. `verbatim` does its own catcode handling, so its
+    body must not be escaped - but its body must also never contain the
+    literal string that would close the environment early, so that one
+    sequence is detected and handled by falling back to an escaped form."""
+    if not text:
+        return ""
+    if r"\end{verbatim}" in text:
+        return r"\texttt{" + latex_escape(text) + "}"
+    return "\\begin{verbatim}\n" + text + "\n\\end{verbatim}"
+
+
+def _tex_paragraphs(text: str) -> str:
+    """Turn plain prose (context.md, scope.md, a verdict summary) into
+    escaped LaTeX paragraphs. Blank-line-separated blocks become paragraphs;
+    single newlines inside a block collapse to spaces."""
+    if not text or not text.strip():
+        return ""
+    blocks = [b.strip() for b in text.replace("\r\n", "\n").split("\n\n")]
+    paragraphs = []
+    for block in blocks:
+        if not block:
+            continue
+        collapsed = " ".join(line.strip() for line in block.splitlines() if line.strip())
+        paragraphs.append(latex_escape(collapsed))
+    return "\n\n".join(paragraphs)
+
+
+# --------------------------------------------------------------------------
+# Data gathering beyond build_report(): the two free-text files and the
+# evidence ledger, none of which are part of the structured report.
+# --------------------------------------------------------------------------
+
+def _read_optional(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ""
+
+
+def _load_evidence_summary(audit: Path) -> list[dict]:
+    """A projection of the absence ledger's controls, same shape the
+    dashboard's Evidence tab reads: id, label, owning lens, evidence state."""
+    path = audit / "evidence" / "absence-ledger.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, UnicodeError, json.JSONDecodeError):
+        return []
+    controls = raw.get("controls") if isinstance(raw, dict) else None
+    if not isinstance(controls, dict):
+        return []
+
+    rows = []
+    for control_id, row in sorted(controls.items()):
+        if not isinstance(row, dict) or row.get("polarity") != "control":
+            continue
+        hits = row.get("hit_count") or 0
+        supports = row.get("supports_state")
+        if hits > 0:
+            state = "CONFIRMED"
+        elif supports in ("NOT_FOUND", "UNVERIFIED"):
+            state = supports
+        else:
+            continue
+        rows.append({
+            "id": control_id,
+            "label": row.get("label") or control_id,
+            "lens": row.get("lens") or "-",
+            "state": state,
+        })
+    return rows
+
+
+def _git_short_ref(root: Path) -> str:
+    """The short ref of HEAD in `root`, or 'nogit' if git is unavailable,
+    the directory is not a repo, or the lookup fails for any reason."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=root, capture_output=True, encoding="utf-8", timeout=15, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "nogit"
+    ref = (result.stdout or "").strip()
+    if result.returncode != 0 or not ref:
+        return "nogit"
+    return ref
+
+
+def _unique_export_dir(audit: Path, ref: str, timestamp: str) -> Path:
+    """`.readiness-audit/export/<ref>-<timestamp>/`, never an existing path.
+    A numeric suffix disambiguates the rare case of two exports landing in
+    the same UTC second."""
+    base_name = f"{ref}-{timestamp}"
+    candidate = audit / "export" / base_name
+    suffix = 1
+    while candidate.exists():
+        candidate = audit / "export" / f"{base_name}-{suffix}"
+        suffix += 1
+    return candidate
+
+
+# --------------------------------------------------------------------------
+# Document rendering
+# --------------------------------------------------------------------------
+
+_PREAMBLE = (
+    "\\documentclass[11pt]{article}\n"
+    "\\usepackage[margin=1in]{geometry}\n"
+    "\\usepackage{parskip}\n"
+    "\\begin{document}\n"
+)
+_POSTAMBLE = "\n\\end{document}\n"
+
+
+def _front_page(report: dict, ref: str, timestamp: str) -> str:
+    counts = report["counts"]
+    verdict = report["verdict"] or {}
+    decision = verdict.get("decision") or "NO VERDICT YET"
+    headline = verdict.get("headline") or ""
+    stage = report.get("stage") or {}
+    complete = stage.get("status") == "complete"
+
+    lines = []
+    A = lines.append
+    A(r"\begin{center}")
+    A(r"{\fontsize{44}{50}\selectfont\bfseries %s}\par" % latex_escape(decision))
+    A(r"\vspace{0.5cm}")
+    if headline:
+        A(r"{\Large %s}\par" % latex_escape(headline))
+        A(r"\vspace{0.5cm}")
+    A(r"{\large P0: %d \quad P1: %d \quad P2: %d \quad P3: %d}\par"
+      % (counts["p0"], counts["p1"], counts["p2"], counts["p3"]))
+    A(r"{\large CONFIRMED: %d \quad NOT FOUND: %d \quad UNVERIFIED: %d}\par"
+      % (counts["confirmed"], counts["notFound"], counts["unverified"]))
+    A(r"\vspace{0.5cm}")
+    A(r"{\normalsize Git ref: \texttt{%s} \quad Exported: \texttt{%s}}\par"
+      % (latex_escape(ref), latex_escape(timestamp)))
+    A(r"\end{center}")
+
+    if not complete:
+        stage_name = stage.get("name") or "not started"
+        not_reported = [lens["label"] for lens in report["lenses"] if lens["status"] != "complete"]
+        A(r"\vspace{0.6cm}")
+        A(r"\begin{center}")
+        A(r"\fbox{\parbox{0.85\textwidth}{\centering")
+        A(r"\textbf{AUDIT INCOMPLETE --- stage reached: %s}\\[4pt]" % latex_escape(stage_name))
+        if not_reported:
+            A(r"Lenses not yet reported: %s" % latex_escape(", ".join(not_reported)))
+        else:
+            A("Every lens has reported, but the audit has not been marked complete.")
+        A(r"}}")
+        A(r"\end{center}")
+    return "\n".join(lines)
+
+
+def _context_scope_verdict(report: dict, context_text: str, scope_text: str) -> str:
+    lines = []
+    A = lines.append
+    A(r"\section*{Context}")
+    A(_tex_paragraphs(context_text) or "Not recorded.")
+    A(r"\section*{Scope}")
+    A(_tex_paragraphs(scope_text) or "Not recorded.")
+    A(r"\section*{Verdict}")
+    verdict = report["verdict"] or {}
+    if verdict.get("decision") or verdict.get("headline"):
+        A(r"\textbf{%s}\\" % latex_escape(verdict.get("decision") or "NO VERDICT YET"))
+        if verdict.get("headline"):
+            A(latex_escape(verdict["headline"]) + r"\\")
+        if verdict.get("summary"):
+            A(_tex_paragraphs(verdict["summary"]))
+    else:
+        A("No verdict has been recorded yet.")
+    return "\n".join(lines)
+
+
+def _evidence_summary(rows: list[dict]) -> str:
+    lines = []
+    A = lines.append
+    A(r"\section*{Evidence Ledger Summary}")
+    if not rows:
+        A("No evidence ledger was found for this audit.")
+        return "\n".join(lines)
+    confirmed = sum(1 for r in rows if r["state"] == "CONFIRMED")
+    not_found = sum(1 for r in rows if r["state"] == "NOT_FOUND")
+    unverified = sum(1 for r in rows if r["state"] == "UNVERIFIED")
+    A(r"%d controls checked: %d confirmed present, %d not found, %d unverified.\par"
+      % (len(rows), confirmed, not_found, unverified))
+    A(r"\vspace{0.2cm}")
+    A(r"\begin{tabular}{lll}")
+    A(r"\textbf{Control} & \textbf{Lens} & \textbf{State} \\")
+    A(r"\hline")
+    for row in rows:
+        A(r"%s & %s & %s \\" % (
+            latex_escape(row["label"]), latex_escape(row["lens"]), latex_escape(row["state"])))
+    A(r"\end{tabular}")
+    return "\n".join(lines)
+
+
+def _render_finding(f: dict) -> str:
+    lines = []
+    A = lines.append
+    A(r"\subsection*{%s -- %s}" % (latex_escape(f["id"]), latex_escape(f.get("title") or "")))
+    A(r"\textbf{State:} %s \quad \textbf{Severity:} %s \quad \textbf{Owner:} %s\\"
+      % (latex_escape(f["state"]), latex_escape(f["severity"]), latex_escape(f.get("owner") or "")))
+    if f.get("cross_lens"):
+        A(r"\textbf{Cross-lens:} %s\\" % latex_escape(", ".join(f["cross_lens"])))
+    if f.get("impact"):
+        A(r"\textbf{Impact:} %s\\" % latex_escape(f["impact"]))
+    if f.get("failure_path"):
+        A(r"\textbf{Why this severity:} %s\\" % latex_escape(f["failure_path"]))
+    if f.get("compensating"):
+        A(r"\textbf{Compensating control:} %s\\" % latex_escape(f["compensating"]))
+    if f.get("evidence"):
+        A(r"\textbf{Evidence:}\\")
+        A(_verbatim_block("\n".join(f["evidence"])))
+    if f.get("probe"):
+        A(r"\textbf{Ledger probe:} \texttt{%s}\\" % latex_escape(f["probe"]))
+    A(r"\textbf{Fix:} %s\\" % latex_escape(f.get("fix") or ""))
+    if f.get("resolve"):
+        A(r"\textbf{Evidence that would resolve this:} %s\\" % latex_escape(f["resolve"]))
+    if f.get("see"):
+        A(r"\textbf{Owned by:} %s\\" % latex_escape(f["see"]))
+    return "\n".join(lines)
+
+
+def _lens_section(report: dict, lens_id: str) -> str:
+    lens_meta = next(lens for lens in report["lenses"] if lens["id"] == lens_id)
+    findings = [f for f in report["findings"] if f["lens"] == lens_id]
+    lines = []
+    A = lines.append
+    A(r"\section*{%s}" % latex_escape(LENS_LABEL[lens_id]))
+    A(r"Status: %s\\" % latex_escape(lens_meta["status"]))
+    if lens_meta.get("skippedReason"):
+        A(r"Skipped reason: %s\\" % latex_escape(lens_meta["skippedReason"]))
+    if not findings:
+        A("No findings recorded for this lens.")
+    else:
+        for f in findings:
+            A(_render_finding(f))
+    return "\n".join(lines)
+
+
+def _unverified_appendix(findings: list[dict]) -> str:
+    unverified = [f for f in findings if f["state"] == "UNVERIFIED"]
+    lines = []
+    A = lines.append
+    A(r"\appendix")
+    A(r"\section*{Appendix: Unverified Findings}")
+    if not unverified:
+        A("No unverified findings.")
+        return "\n".join(lines)
+    for f in unverified:
+        A(r"\subsection*{%s -- %s}" % (latex_escape(f["id"]), latex_escape(f.get("title") or "")))
+        A(r"Lens: %s\\" % latex_escape(f.get("lensLabel") or f.get("lens") or ""))
+        if f.get("resolve"):
+            A(r"Evidence that would resolve this: %s\\" % latex_escape(f["resolve"]))
+    return "\n".join(lines)
+
+
+def _document(report: dict, ref: str, timestamp: str, context_text: str, scope_text: str,
+              evidence_rows: list[dict], lens_id: str | None) -> str:
+    """Build one .tex document. `lens_id=None` builds the combined document
+    with every lens and the full unverified appendix; a lens id builds the
+    single-lens document that carries no other lens's noise."""
+    parts = [
+        _PREAMBLE,
+        _front_page(report, ref, timestamp),
+        r"\clearpage",
+        _context_scope_verdict(report, context_text, scope_text),
+    ]
+    if lens_id is None:
+        parts.append(_evidence_summary(evidence_rows))
+        for lens in LENS_ORDER:
+            parts.append(_lens_section(report, lens))
+        parts.append(_unverified_appendix(report["findings"]))
+    else:
+        parts.append(_lens_section(report, lens_id))
+        lens_findings = [f for f in report["findings"] if f["lens"] == lens_id]
+        parts.append(_unverified_appendix(lens_findings))
+    parts.append(_POSTAMBLE)
+    return "\n\n".join(parts)
+
+
+# --------------------------------------------------------------------------
+# PDF compilation - best effort, never an error when unavailable
+# --------------------------------------------------------------------------
+
+def _find_tex_compiler():
+    """(name, absolute_path) for the first of tectonic, pdflatex found on
+    PATH, or None. Checked in that order: tectonic needs no prior TeX
+    install, so it is preferred when both are present."""
+    for name in ("tectonic", "pdflatex"):
+        path = shutil.which(name)
+        if path:
+            return name, path
+    return None
+
+
+def _compile_pdf(compiler: tuple[str, str], out_dir: Path) -> bool:
+    name, path = compiler
+    if name == "tectonic":
+        cmd = [path, "--outdir", str(out_dir), str(out_dir / "report.tex")]
+    else:
+        cmd = [path, "-interaction=nonstopmode", "-halt-on-error",
+               "-output-directory", str(out_dir), str(out_dir / "report.tex")]
+    try:
+        subprocess.run(cmd, cwd=out_dir, capture_output=True, encoding="utf-8",
+                        timeout=180, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return (out_dir / "report.pdf").exists()
+
+
+# --------------------------------------------------------------------------
+# Entry points
+# --------------------------------------------------------------------------
+
+def export(project_root: Path) -> Path:
+    """Write the full export set for one audit snapshot and return its
+    directory. Safe to call with no audit present, no verdict written, an
+    audit still in progress, and no TeX compiler installed."""
+    root = Path(project_root).expanduser().resolve()
+    audit = root / ".readiness-audit"
+    report = build_report(root)
+
+    ref = _git_short_ref(root)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_dir = _unique_export_dir(audit, ref, timestamp)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    context_text = _read_optional(audit / "context.md")
+    scope_text = _read_optional(audit / "scope.md")
+    evidence_rows = _load_evidence_summary(audit)
+
+    combined = _document(report, ref, timestamp, context_text, scope_text, evidence_rows, None)
+    (out_dir / "report.tex").write_text(combined, encoding="utf-8")
+
+    for lens in LENS_ORDER:
+        doc = _document(report, ref, timestamp, context_text, scope_text, evidence_rows, lens)
+        (out_dir / f"report-{lens}.tex").write_text(doc, encoding="utf-8")
+
+    md_source = audit / "report.md"
+    if md_source.exists():
+        try:
+            (out_dir / "report.md").write_text(
+                md_source.read_text(encoding="utf-8"), encoding="utf-8")
+        except (OSError, UnicodeError):
+            pass
+
+    compiler = _find_tex_compiler()
+    if compiler:
+        _compile_pdf(compiler, out_dir)
+    else:
+        # Written to stderr because export() is also called in-process by the
+        # dashboard server, where stdout belongs to the caller.
+        print("No TeX compiler found on PATH (checked tectonic, pdflatex); the .tex files "
+              f"were written to {out_dir}. Install tectonic (tectonic-typesetting.github.io) "
+              "or a TeX distribution, then run `tectonic report.tex` or `pdflatex report.tex` "
+              "inside that directory to produce report.pdf.", file=sys.stderr)
+
+    return out_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_root", type=Path)
+    args = parser.parse_args(argv)
+    out_dir = export(args.project_root)
+    print(str(out_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/finding_store.py
+++ b/scripts/finding_store.py
@@ -22,7 +22,19 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from severity import FactorError, compute_severity, validate_factors  # noqa: E402
+
 SCHEMA = 1
+
+# The schema of one findings/<lens>.json file, authored by a lens. Bumped from
+# 1 because severity is no longer an authored field: a lens now supplies
+# `factors` and this module derives severity from them. There is deliberately
+# no shim that reads a schema-1 file - inferring factors from a previously
+# authored severity would fabricate evidence-grade data, which is exactly the
+# failure derived severity exists to prevent. An old file must be re-run or
+# archived, not silently reinterpreted.
+FINDING_SCHEMA = 2
 
 STATES = {"CONFIRMED", "NOT_FOUND", "UNVERIFIED"}
 SEVERITIES = {"P0", "P1", "P2", "P3"}
@@ -76,11 +88,26 @@ def normalise_finding(raw: dict, lens: str) -> dict:
     if state not in STATES:
         raise FindingError(f"{fid}: state must be one of {sorted(STATES)}, got {state or 'nothing'}")
 
-    severity = (_text(raw.get("severity")) or "").upper()
-    if severity not in SEVERITIES:
-        raise FindingError(f"{fid}: severity must be one of {sorted(SEVERITIES)}, got {severity or 'nothing'}")
+    # Severity is derived, never authored. A lens that still sets it is
+    # trying to make the highest-stakes judgement in the report by hand.
+    if _text(raw.get("severity")) is not None:
+        raise FindingError(
+            f"{fid}: severity must not be set directly; remove it and supply "
+            "factors instead, so severity is derived from the rubric"
+        )
+
+    factors = raw.get("factors")
+    factor_errors = validate_factors(factors)
+    if factor_errors:
+        raise FindingError(f"{fid}: " + "; ".join(factor_errors))
+
+    try:
+        severity = compute_severity(factors, state)
+    except FactorError as exc:
+        raise FindingError(f"{fid}: {exc}") from exc
 
     finding = {"id": fid, "state": state, "severity": severity,
+               "factors": dict(factors),
                "owner": _text(raw.get("owner")) or lens, "lens": lens}
     for key in TEXT_FIELDS:
         finding[key] = _text(raw.get(key))
@@ -110,6 +137,16 @@ def load_lens(path: Path) -> list[dict]:
         raw = {"findings": raw}
     if not isinstance(raw, dict):
         raise FindingError(f"{lens}: {path.name} must contain an object or a list")
+
+    schema = raw.get("schema")
+    if schema != FINDING_SCHEMA:
+        raise FindingError(
+            f"{lens}: {path.name} declares schema {schema!r}, expected "
+            f"{FINDING_SCHEMA} (findings now carry derived-severity factors "
+            "instead of an authored severity). Re-run this lens to regenerate "
+            "the file in the current schema, or archive the old audit before "
+            "starting a new one."
+        )
 
     findings = raw.get("findings", [])
     if not isinstance(findings, list):
@@ -213,6 +250,22 @@ def load_verdict(root: Path) -> tuple[dict, list[str]]:
     }, errors
 
 
+def compute_decision(findings: list[dict]) -> str:
+    """The go/no-go call, as a pure function of severities: any P0 is HOLD,
+    P1s with no P0 are FIX_THEN_SHIP, otherwise SHIP.
+
+    This is the rule SKILL.md always described as mechanical. It used to be
+    applied by the model when it authored verdict.json by hand; it is now
+    computed here so the same findings always produce the same decision.
+    """
+    severities = {f.get("severity") for f in findings}
+    if "P0" in severities:
+        return "HOLD"
+    if "P1" in severities:
+        return "FIX_THEN_SHIP"
+    return "SHIP"
+
+
 def _counts(findings: list[dict]) -> dict:
     counts = {"total": len(findings), "p0": 0, "p1": 0, "p2": 0, "p3": 0,
               "confirmed": 0, "notFound": 0, "unverified": 0}
@@ -251,6 +304,20 @@ def build_report(root: Path) -> dict:
 
     verdict, verdict_errors = load_verdict(root)
     errors.extend(verdict_errors)
+
+    # The decision the dashboard shows is computed from the findings, never the
+    # one the model typed. It appears only once the audit has finished and
+    # written its verdict, so a half-finished run reads as pending rather than
+    # claiming SHIP because nothing has been found yet.
+    if (state.get("stage_status") == "complete"
+            and (root / ".readiness-audit" / "verdict.json").exists()):
+        computed = compute_decision(findings)
+        authored = verdict.get("decision")
+        if authored and authored != computed:
+            errors.append(
+                f"verdict.json decision {authored} disagrees with the findings, "
+                f"which give {computed}")
+        verdict = {**verdict, "decision": computed}
 
     lenses_with_findings = {f["lens"] for f in findings}
     by_lens = {lens: [f for f in findings if f["lens"] == lens] for lens in LENS_ORDER}

--- a/scripts/launch_dashboard_hook.py
+++ b/scripts/launch_dashboard_hook.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Start the readiness dashboard as soon as an audit begins.
+
+The audit skill also asks the model to start the dashboard, so that the URL
+reaches the transcript. This hook exists because that instruction is advice to
+a language model, and advice is sometimes skipped. The launcher is idempotent,
+so the two paths together start exactly one server.
+
+The hook returns immediately. It never waits for the server to finish starting
+and it never fails an audit: a dashboard is a convenience, and the audit is
+the work.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import readiness_dashboard as dashboard  # noqa: E402
+
+# Matches the two commands that mean "an audit is now under way": the initial
+# state write, and a resume of an existing one.
+AUDIT_START = re.compile(r"audit_state\.py.*\b(init|set-stage)\b")
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    command = str((event.get("tool_input") or {}).get("command", ""))
+    if not AUDIT_START.search(command):
+        return 0
+
+    root = Path(event.get("cwd") or ".")
+    try:
+        if dashboard.find_running(root) is None:
+            dashboard.spawn_detached(root, 0)
+    except Exception:
+        # A dashboard that cannot start is reported by the audit skill, which
+        # has somewhere to say it. A hook has nowhere useful to complain.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/progress.py
+++ b/scripts/progress.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+progress.py - per-lens heartbeats, so a running audit is not a black box.
+
+Seven lens agents run in parallel by default (see audit_state.py LENSES).
+Until a lens writes findings/<lens>.json, the dashboard has no way to tell
+"working" from "stuck" from "never started". This gives each lens a place to
+say what it is doing right now.
+
+Storage is append-only JSON Lines, one file per lens
+(.readiness-audit/progress/<lens>.jsonl). One file per lens is deliberate:
+the lenses run concurrently, and a single shared file would need locking to
+avoid interleaved writes corrupting each other's lines. A lens only ever
+appends to its own file, so no two writers ever touch the same file at once.
+
+An existing progress file is never rewritten or truncated - only appended to.
+
+Usage:
+    python3 progress.py note <project_root> <lens> <phase> ["<text>"]
+    python3 progress.py read <project_root>
+"""
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DIRNAME = ".readiness-audit"
+
+LENSES = ["security", "backend", "frontend", "devops", "qa", "database", "ai-security"]
+PHASES = ["started", "evidence-read", "analyzing", "writing-findings", "done"]
+
+# A lens is treated as having gone quiet if its most recent heartbeat is
+# older than this many seconds and it has not reported "done".
+SILENCE_THRESHOLD_SECONDS = 120
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _progress_dir(root: Path) -> Path:
+    return root / DIRNAME / "progress"
+
+
+def _progress_file(root: Path, lens: str) -> Path:
+    return _progress_dir(root) / f"{lens}.jsonl"
+
+
+def append_note(root: Path, lens: str, phase: str, note: str | None) -> dict:
+    """Append one heartbeat to <lens>.jsonl. Raises ValueError for a bad lens/phase."""
+    if lens not in LENSES:
+        raise ValueError(f"unknown lens {lens!r}; expected one of {LENSES}")
+    if phase not in PHASES:
+        raise ValueError(f"unknown phase {phase!r}; expected one of {PHASES}")
+
+    event = {
+        "ts": _now_iso(),
+        "lens": lens,
+        "phase": phase,
+        "note": note or None,
+    }
+
+    directory = _progress_dir(root)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = _progress_file(root, lens)
+    # "a" opens for append and never truncates an existing file. A single
+    # line write is not guaranteed atomic across processes on every
+    # filesystem, but each lens only ever appends to its own file, so there
+    # is no concurrent writer to interleave with.
+    with open(path, "a", encoding="utf-8", newline="\n") as fh:
+        fh.write(json.dumps(event) + "\n")
+    return event
+
+
+def _load_events(path: Path) -> list[dict]:
+    """Read every well-formed event from a lens's progress file, in order.
+
+    A malformed line (partial write, corruption) is skipped rather than
+    treated as fatal - a dashboard polling every two seconds must be able to
+    read a file another process is mid-write on without breaking.
+    """
+    events = []
+    if not path.exists():
+        return events
+    with open(path, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            if not {"ts", "lens", "phase"} <= event.keys():
+                continue
+            events.append(event)
+    return events
+
+
+def read_progress(root: Path) -> dict:
+    """Every lens's heartbeat history, for the dashboard to poll directly.
+
+    Returns a dict keyed by lens id. A lens that has never emitted a
+    heartbeat gets an empty events list and no fabricated progress - honest
+    silence, not invented activity.
+    """
+    now = datetime.now(timezone.utc)
+    result = {}
+    for lens in LENSES:
+        events = _load_events(_progress_file(root, lens))
+        latest = events[-1] if events else None
+        latest_phase = latest["phase"] if latest else None
+        latest_ts = latest["ts"] if latest else None
+
+        seconds_since = None
+        signal = "no-signal"
+        if latest_ts is not None:
+            try:
+                latest_dt = datetime.fromisoformat(latest_ts)
+                if latest_dt.tzinfo is None:
+                    latest_dt = latest_dt.replace(tzinfo=timezone.utc)
+                seconds_since = (now - latest_dt).total_seconds()
+                if latest_phase == "done" or seconds_since <= SILENCE_THRESHOLD_SECONDS:
+                    signal = "active"
+            except ValueError:
+                seconds_since = None
+                signal = "no-signal"
+
+        result[lens] = {
+            "events": events,
+            "latest_phase": latest_phase,
+            "latest_ts": latest_ts,
+            "seconds_since_latest": seconds_since,
+            "signal": signal,
+        }
+    return result
+
+
+def cmd_note(root: Path, lens: str, phase: str, note: str | None) -> int:
+    try:
+        event = append_note(root, lens, phase, note)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(event, indent=2))
+    return 0
+
+
+def cmd_read(root: Path) -> int:
+    print(json.dumps(read_progress(root), indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("note")
+    s.add_argument("project_root")
+    s.add_argument("lens")
+    s.add_argument("phase")
+    s.add_argument("note", nargs="?", default=None)
+
+    s = sub.add_parser("read")
+    s.add_argument("project_root")
+
+    args = ap.parse_args(argv)
+
+    root = Path(args.project_root).expanduser().resolve()
+    if not root.is_dir():
+        print(f"not a directory: {root}", file=sys.stderr)
+        return 1
+
+    if args.cmd == "note":
+        return cmd_note(root, args.lens, args.phase, args.note)
+    if args.cmd == "read":
+        return cmd_read(root)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/readiness_dashboard.py
+++ b/scripts/readiness_dashboard.py
@@ -10,7 +10,16 @@ should never have to read a file path to get an answer.
 
 import argparse
 import json
+import os
+import signal
+import subprocess
 import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+import webbrowser
+from datetime import datetime, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -19,6 +28,17 @@ from urllib.parse import urlsplit
 sys.path.insert(0, str(Path(__file__).parent))
 
 from finding_store import LENS_LABEL, LENS_ORDER, build_report  # noqa: E402
+from progress import read_progress  # noqa: E402
+
+# Bumped when the shape of dashboard.json changes. A handshake file carrying an
+# unknown version is treated as stale rather than migrated: it is a cache, and
+# the running server is the source of truth.
+HANDSHAKE_SCHEMA = 1
+HANDSHAKE_NAME = "dashboard.json"
+LOG_NAME = "dashboard.log"
+HANDSHAKE_TIMEOUT_SECONDS = 5.0
+HEALTH_TIMEOUT_SECONDS = 0.5
+IDLE_TIMEOUT_SECONDS = 3600.0
 
 DASHBOARD_HTML = """<!doctype html>
 <html lang="en">
@@ -69,6 +89,17 @@ DASHBOARD_HTML = """<!doctype html>
       .live { display:flex; align-items:center; gap:7px; font-size:.83rem; font-weight:650; color:var(--green); }
       .live:before { content:""; width:8px; height:8px; border-radius:50%; background:currentColor; box-shadow:0 0 0 4px #d9f3e8; }
       .live.done { color:var(--muted); } .live.done:before { box-shadow:0 0 0 4px #e6e9e8; }
+      .export { border:1px solid var(--line); background:var(--white); border-radius:8px;
+        padding:7px 11px; font-size:.82rem; font-weight:750; color:var(--ink); }
+      .export:hover:enabled { border-color:#5c8ce2; color:var(--blue); }
+      .export:disabled { opacity:.55; cursor:progress; }
+
+      .feed { list-style:none; margin:16px 0 0; padding:0; }
+      .feed li { display:grid; grid-template-columns:150px 130px minmax(0,1fr) auto; gap:12px;
+        padding:9px 0; border-bottom:1px solid var(--line); font-size:.85rem; align-items:baseline; }
+      .feed b { font-size:.83rem; }
+      .feed .phase { color:var(--blue); font-weight:650; font-size:.78rem; }
+      .lens em.silent { color:var(--amber); }
 
       .hero { display:grid; grid-template-columns:1.4fr .6fr; gap:36px; align-items:end; padding:52px 0 34px; }
       .decision { display:inline-flex; align-items:center; gap:8px; padding:6px 12px; border-radius:999px;
@@ -177,6 +208,7 @@ DASHBOARD_HTML = """<!doctype html>
       @media (max-width:860px) {
         .hero { grid-template-columns:1fr; gap:26px; padding:34px 0 26px; }
         .matrix { grid-template-columns:repeat(4,1fr); }
+        .feed li { grid-template-columns:1fr; gap:2px; }
       }
       @media (max-width:620px) {
         .shell { padding:20px 17px 70px; }
@@ -197,6 +229,7 @@ DASHBOARD_HTML = """<!doctype html>
     <script>
       const app = document.getElementById('app');
       let snapshot = null;
+      let exportResult = null;
 
       const ROUTES = ['overview', 'findings', 'evidence', 'report'];
       const SEVERITY_ORDER = ['P0', 'P1', 'P2', 'P3'];
@@ -249,6 +282,7 @@ DASHBOARD_HTML = """<!doctype html>
           <div class="brand"><span class="mark" aria-hidden="true"></span> prod-readiness</div>
           <nav class="nav" aria-label="Dashboard views">${tabs.map(([id, label]) =>
             `<button type="button" data-view="${id}" ${current === id ? 'aria-current="page"' : ''}>${label}</button>`).join('')}</nav>
+          <button type="button" class="export" data-export="1">Export report</button>
           <span class="live ${running ? '' : 'done'}">${running ? 'Audit running' : 'Audit complete'}</span>
         </header>`;
       }
@@ -295,21 +329,92 @@ DASHBOARD_HTML = """<!doctype html>
         </section>`;
       }
 
+      const PHASE_LABEL = {
+        'started': 'Starting', 'evidence-read': 'Reading evidence', 'analyzing': 'Analyzing',
+        'writing-findings': 'Writing findings', 'done': 'Finished'
+      };
+
+      function elapsed(seconds) {
+        if (seconds == null) return '';
+        const value = Math.max(0, Math.round(seconds));
+        if (value < 60) return `${value}s ago`;
+        if (value < 3600) return `${Math.round(value / 60)}m ago`;
+        return `${Math.round(value / 3600)}h ago`;
+      }
+
+      // A lens that has said nothing is shown as silent, never as progress. An
+      // invented "in progress" is the one thing a live view must not do.
+      function lensActivity(lensId) {
+        const record = (snapshot.progress || {})[lensId];
+        if (!record || !record.events || !record.events.length) return null;
+        const latest = record.events[record.events.length - 1];
+        return {
+          phase: PHASE_LABEL[latest.phase] || latest.phase,
+          note: latest.note || '',
+          when: elapsed(record.seconds_since_latest),
+          silent: record.signal === 'no-signal'
+        };
+      }
+
       function lensMatrix() {
         const cells = snapshot.lenses.map(lens => {
+          const activity = lensActivity(lens.id);
           const worst = lens.counts.p0 ? `${lens.counts.p0} blocking`
             : lens.counts.p1 ? `${lens.counts.p1} to fix`
             : lens.counts.total ? `${lens.counts.total} noted`
             : { complete: 'Nothing found', skipped: 'Not applicable', running: 'Reviewing now' }[lens.status] || 'Waiting';
+          const live = activity && lens.status !== 'complete'
+            ? `<em class="${activity.silent ? 'silent' : ''}">${escapeHtml(
+                activity.silent ? `No signal since ${activity.when}` : `${activity.phase} - ${activity.when}`)}</em>`
+            : '';
           return `<button class="lens ${escapeHtml(lens.status)}" type="button" data-lens="${escapeHtml(lens.id)}">
             <span class="dot ${escapeHtml(lens.status)}" aria-hidden="true"></span>
             <b>${escapeHtml(lens.label)}</b>
+            ${live}
             <em>${escapeHtml(worst)}</em>
           </button>`;
         }).join('');
         return `<section class="band"><div class="band-head"><h2>What was reviewed</h2>
           <p>Seven specialists, each writing only its own findings.</p></div>
           <div class="matrix">${cells}</div></section>`;
+      }
+
+      function activityFeed() {
+        const progress = snapshot.progress || {};
+        const events = [];
+        Object.entries(progress).forEach(([lensId, record]) =>
+          (record.events || []).forEach(event => events.push({ ...event, lensId })));
+        if (!events.length) return '';
+        events.sort((a, b) => String(b.ts).localeCompare(String(a.ts)));
+        const labelFor = id => (snapshot.lenses.find(lens => lens.id === id) || {}).label || id;
+        const rows = events.slice(0, 40).map(event => `<li>
+          <b>${escapeHtml(labelFor(event.lensId))}</b>
+          <span class="phase">${escapeHtml(PHASE_LABEL[event.phase] || event.phase)}</span>
+          <span>${escapeHtml(event.note || '')}</span>
+          <time class="mono muted">${escapeHtml(String(event.ts).slice(11, 19))}</time>
+        </li>`).join('');
+        return `<section class="band"><div class="band-head"><h2>Activity</h2>
+          <p>What each specialist reported while it worked.</p></div>
+          <ul class="feed">${rows}</ul></section>`;
+      }
+
+      async function runExport(button) {
+        button.disabled = true;
+        const original = button.textContent;
+        button.textContent = 'Exporting...';
+        try {
+          const response = await fetch('/api/export', { method: 'POST' });
+          const result = await response.json();
+          button.textContent = result.ok ? 'Exported' : 'Export failed';
+          exportResult = result.ok
+            ? `Export written to ${result.directory}`
+            : `Export failed: ${result.error || 'unknown error'}`;
+        } catch (error) {
+          button.textContent = 'Export failed';
+          exportResult = `Export failed: ${error.message || error}`;
+        }
+        render();
+        setTimeout(() => { button.textContent = original; button.disabled = false; }, 4000);
       }
 
       function findingRow(finding) {
@@ -341,7 +446,9 @@ DASHBOARD_HTML = """<!doctype html>
         const notice = errors.length
           ? `<div class="notice">${escapeHtml(errors[0])}${errors.length > 1 ? ` (and ${errors.length - 1} more)` : ''}</div>`
           : '';
-        return `${hero()}${notice}${topFindings()}${lensMatrix()}`;
+        const exported = exportResult
+          ? `<div class="notice mono">${escapeHtml(exportResult)}</div>` : '';
+        return `${hero()}${notice}${exported}${topFindings()}${lensMatrix()}${activityFeed()}`;
       }
 
       function findingsView() {
@@ -529,6 +636,8 @@ DASHBOARD_HTML = """<!doctype html>
       }
 
       app.addEventListener('click', event => {
+        const exportButton = event.target.closest('[data-export]');
+        if (exportButton) return runExport(exportButton);
         const view = event.target.closest('[data-view]');
         if (view) return navigate({ view: view.dataset.view, finding: null, open: null });
         const finding = event.target.closest('[data-finding]');
@@ -561,12 +670,22 @@ DASHBOARD_HTML = """<!doctype html>
           snapshot = await response.json();
           render();
           if (snapshot.status === 'running') setTimeout(refresh, 2000);
+          else setTimeout(keepalive, 30000);
         } catch (error) {
           app.innerHTML = `<div class="shell"><section class="band" style="border-top:0">
             <h1>Production readiness</h1>
             <p class="lede">${escapeHtml(error.message || 'The snapshot could not be loaded.')}</p>
           </section></div>`;
         }
+      }
+
+      // A finished audit stops polling for new data, but the server counts
+      // requests to decide whether anyone is still reading. Without this an
+      // open tab would go quiet and the idle timer would close the report out
+      // from under the person reading it.
+      async function keepalive() {
+        try { await fetch('/api/ping'); } catch (error) { return; }
+        setTimeout(keepalive, 30000);
       }
 
       refresh();
@@ -648,6 +767,7 @@ def build_snapshot(project_root: Path) -> dict:
                        for lens in LENS_ORDER],
             "findings": [],
             "evidence": [],
+            "progress": {},
             "gitRef": None,
             "errors": [],
         }
@@ -658,6 +778,7 @@ def build_snapshot(project_root: Path) -> dict:
     report["message"] = ("Audit complete." if report["status"] == "complete"
                          else "Audit is still running.")
     report["evidence"] = load_evidence(audit_root)
+    report["progress"] = read_progress(project_root)
     report["auditRoot"] = str(audit_root)
     return report
 
@@ -667,7 +788,14 @@ class DashboardServer(ThreadingHTTPServer):
 
     def __init__(self, project_root: Path, port: int):
         self.project_root = project_root
+        self.last_activity = time.monotonic()
         super().__init__(("127.0.0.1", port), DashboardRequestHandler)
+
+    def note_activity(self) -> None:
+        self.last_activity = time.monotonic()
+
+    def seconds_idle(self) -> float:
+        return time.monotonic() - self.last_activity
 
 
 class DashboardRequestHandler(BaseHTTPRequestHandler):
@@ -675,13 +803,38 @@ class DashboardRequestHandler(BaseHTTPRequestHandler):
         # The dashboard keeps its view, filters, and open finding in the query
         # string, so every route arrives here as "/?view=..." and must still
         # serve the app shell.
+        self.server.note_activity()
         path = urlsplit(self.path).path
         if path == "/":
             return self.respond(HTTPStatus.OK, "text/html; charset=utf-8", DASHBOARD_HTML.encode())
         if path == "/api/snapshot":
             payload = json.dumps(build_snapshot(self.server.project_root)).encode()
             return self.respond(HTTPStatus.OK, "application/json; charset=utf-8", payload)
+        if path == "/api/ping":
+            # Deliberately cheap. Its only job is to prove a reader is still
+            # here, so it must not rebuild the report.
+            return self.respond(HTTPStatus.OK, "application/json; charset=utf-8", b'{"ok":true}')
         self.send_error(HTTPStatus.NOT_FOUND)
+
+    def do_POST(self):
+        # The one write the dashboard performs. It produces derived documents
+        # under .readiness-audit/export/ and touches no audit state, so the
+        # dashboard stays an observer of the audit rather than a control over
+        # it.
+        self.server.note_activity()
+        if urlsplit(self.path).path != "/api/export":
+            return self.send_error(HTTPStatus.NOT_FOUND)
+        try:
+            from export_report import export
+
+            directory = export(self.server.project_root)
+        except Exception as error:  # noqa: BLE001 - reported to the browser
+            payload = json.dumps({"ok": False, "error": str(error)}).encode()
+            return self.respond(HTTPStatus.INTERNAL_SERVER_ERROR,
+                                "application/json; charset=utf-8", payload)
+        files = sorted(item.name for item in Path(directory).iterdir())
+        payload = json.dumps({"ok": True, "directory": str(directory), "files": files}).encode()
+        return self.respond(HTTPStatus.OK, "application/json; charset=utf-8", payload)
 
     def respond(self, status: HTTPStatus, content_type: str, body: bytes):
         self.send_response(status)
@@ -703,21 +856,246 @@ def startup_url(server: DashboardServer) -> str:
     return f"http://{host}:{port}/"
 
 
-def serve(project_root: Path, port: int = 0) -> None:
+# --------------------------------------------------------------------------
+# Handshake file
+#
+# The launcher and the server communicate through one small file rather than
+# through stdout. Scraping a log line for a URL is what made starting the
+# dashboard unreliable: it depended on whoever ran the command reading the
+# output correctly and at the right moment.
+# --------------------------------------------------------------------------
+
+
+def audit_root_for(project_root: Path) -> Path:
+    return (Path(project_root) / ".readiness-audit").resolve()
+
+
+def handshake_path(project_root: Path) -> Path:
+    return audit_root_for(project_root) / HANDSHAKE_NAME
+
+
+def write_handshake(project_root: Path, url: str, port: int) -> Path:
+    """Publish the running server's address, atomically."""
+    path = handshake_path(project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": HANDSHAKE_SCHEMA,
+        "url": url,
+        "port": port,
+        "pid": os.getpid(),
+        "audit_root": str(audit_root_for(project_root)),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+    return path
+
+
+def read_handshake(project_root: Path) -> dict | None:
+    """Return a usable handshake record, or None.
+
+    Anything unreadable, malformed, incomplete, or written by a schema this
+    version does not know is reported as absent. The file is a cache; a bad
+    cache entry must never block a launch.
+    """
+    path = handshake_path(project_root)
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(record, dict) or record.get("schema") != HANDSHAKE_SCHEMA:
+        return None
+    if not all(record.get(key) for key in ("url", "pid", "audit_root")):
+        return None
+    return record
+
+
+def health_check(url: str, expected_audit_root: Path,
+                 timeout: float = HEALTH_TIMEOUT_SECONDS) -> bool:
+    """Is a dashboard for *this* audit answering on that URL?
+
+    A live port serving the right audit root is proof. A recorded PID is not:
+    process identifiers are reused, so trusting one can point at a stranger's
+    process after a reboot.
+    """
+    try:
+        with urllib.request.urlopen(url.rstrip("/") + "/api/snapshot", timeout=timeout) as response:
+            if response.status != HTTPStatus.OK:
+                return False
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        return False
+    return payload.get("auditRoot") == str(expected_audit_root)
+
+
+def find_running(project_root: Path) -> dict | None:
+    """The healthy dashboard already serving this audit, if there is one."""
+    record = read_handshake(project_root)
+    if record is None:
+        return None
+    if record["audit_root"] != str(audit_root_for(project_root)):
+        return None
+    if not health_check(record["url"], audit_root_for(project_root)):
+        return None
+    return record
+
+
+# --------------------------------------------------------------------------
+# Serving
+# --------------------------------------------------------------------------
+
+
+def _watch_idle(server: DashboardServer, timeout: float) -> None:
+    while True:
+        time.sleep(min(30.0, max(1.0, timeout / 4)))
+        if server.seconds_idle() > timeout:
+            threading.Thread(target=server.shutdown, daemon=True).start()
+            return
+
+
+def serve(project_root: Path, port: int = 0,
+          idle_timeout: float | None = IDLE_TIMEOUT_SECONDS) -> None:
+    """Run the server in this process until it is stopped or goes idle."""
     server = create_server(project_root, port)
-    print(startup_url(server), flush=True)
+    url = startup_url(server)
+    write_handshake(project_root, url, server.server_address[1])
+    print(url, flush=True)
+    if idle_timeout:
+        threading.Thread(target=_watch_idle, args=(server, idle_timeout), daemon=True).start()
     try:
         server.serve_forever()
     finally:
         server.server_close()
+        _clear_own_handshake(project_root)
+
+
+def _clear_own_handshake(project_root: Path) -> None:
+    record = read_handshake(project_root)
+    if record and record.get("pid") == os.getpid():
+        handshake_path(project_root).unlink(missing_ok=True)
+
+
+# --------------------------------------------------------------------------
+# Launching
+# --------------------------------------------------------------------------
+
+
+def spawn_detached(project_root: Path, port: int) -> None:
+    """Start the server in a process that survives this one.
+
+    The dashboard outlives the session that started it, because a reviewer
+    reads the report after the audit ends. os.fork is unavailable on Windows,
+    so the launcher re-runs this same file in server mode instead.
+    """
+    audit_root = audit_root_for(project_root)
+    audit_root.mkdir(parents=True, exist_ok=True)
+    log_path = audit_root / LOG_NAME
+    command = [sys.executable, str(Path(__file__).resolve()),
+               str(Path(project_root).resolve()), "--serve", "--port", str(port)]
+
+    kwargs: dict = {}
+    if os.name == "nt":
+        kwargs["creationflags"] = (subprocess.CREATE_NEW_PROCESS_GROUP
+                                   | getattr(subprocess, "DETACHED_PROCESS", 0x00000008))
+    else:
+        kwargs["start_new_session"] = True
+
+    # Truncated on every real start. When the handshake times out this file is
+    # the only diagnosis available, so it is written rather than discarded.
+    log = open(log_path, "w", encoding="utf-8")
+    try:
+        subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT,
+                         stdin=subprocess.DEVNULL, close_fds=True, **kwargs)
+    finally:
+        log.close()
+
+
+def _await_handshake(project_root: Path, timeout: float) -> dict | None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        record = find_running(project_root)
+        if record is not None:
+            return record
+        time.sleep(0.1)
+    return None
+
+
+def open_browser(url: str) -> bool:
+    """Open the dashboard if this machine plausibly has a browser."""
+    if os.environ.get("CLAUDE_CODE_REMOTE"):
+        return False
+    try:
+        return bool(webbrowser.open(url))
+    except Exception:
+        return False
+
+
+def launch(project_root: Path, port: int = 0, open_in_browser: bool = True,
+           timeout: float = HANDSHAKE_TIMEOUT_SECONDS) -> dict | None:
+    """Ensure a dashboard is serving this audit, and return its record.
+
+    Idempotent by design: the audit skill and the launch hook may both call
+    this, and a second call must reuse the first server rather than start a
+    competing one.
+    """
+    running = find_running(project_root)
+    if running is None:
+        spawn_detached(project_root, port)
+        running = _await_handshake(project_root, timeout)
+    if running is None:
+        return None
+    if open_in_browser:
+        open_browser(running["url"])
+    return running
+
+
+def stop(project_root: Path) -> bool:
+    """Stop the dashboard serving this audit, if it is really ours.
+
+    Identity is checked before anything is signalled. A handshake file that
+    fails its health check is stale, and a stale record is deleted rather than
+    used to kill whatever now owns that process identifier.
+    """
+    record = read_handshake(project_root)
+    if record is None:
+        return False
+    if not health_check(record["url"], audit_root_for(project_root)):
+        handshake_path(project_root).unlink(missing_ok=True)
+        return False
+    try:
+        os.kill(int(record["pid"]), signal.SIGTERM)
+    except (OSError, ValueError, TypeError):
+        return False
+    handshake_path(project_root).unlink(missing_ok=True)
+    return True
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Serve a read-only production-readiness dashboard.")
     parser.add_argument("project_root", type=Path, help="Target project root containing .readiness-audit")
     parser.add_argument("--port", type=int, default=0, help="Port to bind on 127.0.0.1 (default: ephemeral)")
+    parser.add_argument("--serve", action="store_true",
+                        help="Run the server in this process (used by the launcher)")
+    parser.add_argument("--no-open", action="store_true", help="Do not open a browser")
+    parser.add_argument("--stop", action="store_true", help="Stop the dashboard for this project")
     args = parser.parse_args(argv)
-    serve(args.project_root, args.port)
+
+    if args.stop:
+        stopped = stop(args.project_root)
+        print("stopped" if stopped else "no running dashboard found", flush=True)
+        return 0 if stopped else 1
+
+    if args.serve:
+        serve(args.project_root, args.port)
+        return 0
+
+    record = launch(args.project_root, args.port, open_in_browser=not args.no_open)
+    if record is None:
+        log = audit_root_for(args.project_root) / LOG_NAME
+        print(f"dashboard failed to start; see {log}", file=sys.stderr, flush=True)
+        return 1
+    print(record["url"], flush=True)
     return 0
 
 

--- a/scripts/severity.py
+++ b/scripts/severity.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+severity.py - deterministic severity from a finding's factors.
+
+Lenses no longer choose a severity. Two runs of the same audit used to grade
+the same gap P1 one time and P3 the next, because severity was a judgement
+call made once per finding, by whichever lens got there first. That judgement
+is now split into four closed properties any two readers would code the same
+way - exposure, data sensitivity, blast radius, and whether a compensating
+control is present - and this module turns that description into P0-P3 by a
+single published rubric. The same factors always produce the same severity,
+on every run, from every lens.
+
+Rubric (kept as data below, not as nested conditionals, so it can be read and
+audited without tracing code):
+
+    exposure                points
+    ------------------------------
+    internet                 3
+    authenticated             2
+    internal                  1
+    local                      0
+
+    data_class               points
+    ------------------------------
+    secrets                   3
+    pii                       3
+    financial                  3
+    business                   1
+    none                        0
+
+    blast_radius              points
+    ------------------------------
+    systemic                  3
+    multi-tenant               2
+    single-tenant                1
+    single-user                   0
+
+    compensating_control == "present"  ->  subtract 2 (floor the total at 0)
+
+    total >= 8   ->  P0
+    total 6-7    ->  P1
+    total 3-5    ->  P2
+    total <= 2   ->  P3
+
+Hard cap: a finding whose evidence state is UNVERIFIED can never be P0. If the
+rubric produces P0 for an UNVERIFIED finding, `compute_severity` records it as
+P1 instead. Uncertainty must never escalate severity.
+"""
+from __future__ import annotations
+
+# Point value per factor value. Expressed as data, not as if/elif chains, so
+# the rubric above and the code below cannot silently disagree.
+EXPOSURE_POINTS = {
+    "internet": 3,
+    "authenticated": 2,
+    "internal": 1,
+    "local": 0,
+}
+
+DATA_CLASS_POINTS = {
+    "secrets": 3,
+    "pii": 3,
+    "financial": 3,
+    "business": 1,
+    "none": 0,
+}
+
+BLAST_RADIUS_POINTS = {
+    "systemic": 3,
+    "multi-tenant": 2,
+    "single-tenant": 1,
+    "single-user": 0,
+}
+
+# Not a point value on its own - a signed adjustment applied after the three
+# scores above are summed.
+COMPENSATING_CONTROL_ADJUSTMENT = {
+    "present": -2,
+    "absent": 0,
+}
+
+# The four factors a finding must supply, and the closed enum of values each
+# one accepts. validate_findings.py and finding_store.py both read this table,
+# so an error message listing "allowed values" can never drift from what
+# scoring actually accepts.
+FACTORS = {
+    "exposure": EXPOSURE_POINTS,
+    "data_class": DATA_CLASS_POINTS,
+    "blast_radius": BLAST_RADIUS_POINTS,
+    "compensating_control": COMPENSATING_CONTROL_ADJUSTMENT,
+}
+FACTOR_KEYS = tuple(FACTORS)
+
+# Rubric total -> severity. Ordered highest threshold first; the first
+# threshold the total meets or exceeds wins. Expressed as data so the
+# boundaries in the docstring above are the boundaries the code applies.
+SEVERITY_THRESHOLDS = (
+    (8, "P0"),
+    (6, "P1"),
+    (3, "P2"),
+    (0, "P3"),
+)
+
+UNVERIFIED_STATE = "UNVERIFIED"
+UNVERIFIED_SEVERITY_CAP = "P1"
+
+
+class FactorError(ValueError):
+    """`factors` is missing, not an object, or has a value outside its enum."""
+
+
+def validate_factors(factors) -> list[str]:
+    """Return one message per problem with `factors`; [] means it is valid.
+
+    Each message names the offending key and lists the values it accepts, so
+    a caller can surface it directly without re-deriving the rubric.
+    """
+    if not isinstance(factors, dict):
+        return [
+            "factors is required and must be an object with keys "
+            + ", ".join(FACTOR_KEYS)
+        ]
+
+    errors = []
+    for key, allowed in FACTORS.items():
+        if key not in factors or factors[key] in (None, ""):
+            errors.append(
+                f"factors.{key} is required; allowed values: {', '.join(allowed)}"
+            )
+            continue
+        value = factors[key]
+        if value not in allowed:
+            errors.append(
+                f"factors.{key} must be one of {', '.join(allowed)}, got {value!r}"
+            )
+    return errors
+
+
+def score_factors(factors: dict) -> int:
+    """Sum the rubric points for an already-valid factors object.
+
+    Assumes `validate_factors(factors) == []`; call that first if the input
+    is not already known to be valid, since this indexes the enum tables
+    directly and raises KeyError on a bad value.
+    """
+    total = (
+        EXPOSURE_POINTS[factors["exposure"]]
+        + DATA_CLASS_POINTS[factors["data_class"]]
+        + BLAST_RADIUS_POINTS[factors["blast_radius"]]
+        + COMPENSATING_CONTROL_ADJUSTMENT[factors["compensating_control"]]
+    )
+    return max(total, 0)
+
+
+def severity_for_score(total: int) -> str:
+    """Map a rubric total to P0-P3 using SEVERITY_THRESHOLDS."""
+    for minimum, severity in SEVERITY_THRESHOLDS:
+        if total >= minimum:
+            return severity
+    return "P3"  # unreachable: the lowest threshold is 0 and total is floored
+
+
+def compute_severity(factors: dict, state: str) -> str:
+    """Derive severity from factors, applying the UNVERIFIED-cannot-be-P0 cap.
+
+    Raises FactorError if `factors` is missing or has an invalid value. Call
+    `validate_factors` first if you want every problem reported at once
+    rather than an exception on the first one.
+    """
+    errors = validate_factors(factors)
+    if errors:
+        raise FactorError("; ".join(errors))
+
+    severity = severity_for_score(score_factors(factors))
+    if severity == "P0" and str(state).strip().upper() == UNVERIFIED_STATE:
+        severity = UNVERIFIED_SEVERITY_CAP
+    return severity

--- a/scripts/validate_findings.py
+++ b/scripts/validate_findings.py
@@ -13,6 +13,10 @@ It enforces the rules that are easy to state and easy to quietly break:
     (or states there is none)
   * absence is phrased as "not found in reviewed scope", never as "does not exist"
   * the same finding does not appear under two lenses
+  * severity is never hand-set; a finding supplies `factors` and severity is
+    derived from the published rubric (see severity.py)
+  * a verdict.json decision, if present, must agree with the decision computed
+    from the validated findings
 
 Errors block the report. Warnings are judgement calls worth a second look.
 
@@ -24,6 +28,10 @@ import json
 import re
 import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from severity import compute_severity, validate_factors  # noqa: E402
+from finding_store import FINDING_SCHEMA, compute_decision, load_verdict  # noqa: E402
 
 STATES = {"CONFIRMED", "NOT_FOUND", "UNVERIFIED"}
 SEVERITIES = {"P0", "P1", "P2", "P3"}
@@ -50,7 +58,7 @@ CODE_SHAPED = re.compile(r"`[^`]+`|[\w-]+/[\w./-]+|\b\w+\.(?:ts|tsx|js|jsx|py|go
 # The authored JSON uses snake_case; the rules below were written against the
 # markdown field names. Mapping once here keeps every rule untouched.
 JSON_TO_FIELD = {
-    "state": "state", "severity": "severity", "owner": "owner",
+    "state": "state", "owner": "owner",
     "cross_lens": "cross-lens", "evidence": "evidence", "probe": "probe",
     "impact": "impact", "failure_path": "failure-path",
     "compensating": "compensating", "fix": "fix", "resolve": "resolve", "see": "see",
@@ -74,6 +82,15 @@ def parse_file(path: Path):
     if not isinstance(raw, dict) or not isinstance(raw.get("findings", []), list):
         raise ValueError(f"{path.name} must be an object with a 'findings' list")
 
+    schema = raw.get("schema")
+    if schema != FINDING_SCHEMA:
+        raise ValueError(
+            f"{path.name} declares schema {schema!r}, expected {FINDING_SCHEMA} "
+            "(severity is now derived from factors, not authored). Re-run this "
+            "lens to regenerate the file in the current schema, or archive the "
+            "old audit before starting a new one."
+        )
+
     findings = []
     for index, item in enumerate(raw.get("findings", []), 1):
         if not isinstance(item, dict):
@@ -90,12 +107,32 @@ def parse_file(path: Path):
             "_line": index,
             "_file": path.name,
             "fields": fields,
+            # kept raw (not stringified through `fields`) so factor values
+            # are matched against the rubric's enums exactly as authored
+            "factors": item.get("factors"),
+            "severity_provided": item.get("severity") not in (None, "", "-"),
         })
     return findings
 
 
 def empty(v):
     return v is None or v.strip() in ("", "-", "n/a", "N/A", "none")
+
+
+def derive_severity(fd: dict) -> str:
+    """Severity for one finding as parsed by `parse_file`.
+
+    Mirrors the derivation `validate()` performs per finding, for callers
+    (assemble_report.py) that need a severity string without re-running the
+    full validation pass. Returns "?" if factors are missing or invalid,
+    rather than raising, since a caller reaching this point has typically
+    already run `validate()` and decided how to handle its errors (including,
+    with --force, choosing to render anyway).
+    """
+    state = fd["fields"].get("state", "").strip().upper().replace(" ", "_")
+    if validate_factors(fd.get("factors")):
+        return "?"
+    return compute_severity(fd["factors"], state)
 
 
 def validate(root: Path):
@@ -153,9 +190,18 @@ def validate(root: Path):
         state = F.get("state", "").strip().upper().replace(" ", "_")
         if state not in STATES:
             err(f"state must be one of {sorted(STATES)}, got {F.get('state')!r}")
-        sev = F.get("severity", "").strip().upper()
-        if sev not in SEVERITIES:
-            err(f"severity must be one of {sorted(SEVERITIES)}, got {F.get('severity')!r}")
+
+        # Severity is derived, never authored. A finding that sets it by hand
+        # is trying to make the report's highest-stakes judgement itself.
+        if fd.get("severity_provided"):
+            err("severity must not be set directly; remove it and supply "
+                "factors instead, so severity is derived from the rubric")
+
+        factor_errors = validate_factors(fd.get("factors"))
+        for msg in factor_errors:
+            err(msg)
+        sev = "" if factor_errors else compute_severity(fd["factors"], state)
+        F["severity"] = sev or "?"
 
         if empty(F.get("fix")):
             err("no fix given; a finding without a concrete remediation is an observation, not a finding")
@@ -257,6 +303,25 @@ def validate(root: Path):
                                ", ".join(ids),
                                f"same underlying issue ({fp}) reported by {sorted(lenses)}; "
                                "one lens owns it fully, the others add see: <owner-id>"))
+
+    # decision cross-check: the go/no-go call is computed from severities,
+    # never authored by hand. If verdict.json states one anyway, it must
+    # agree - a disagreement is a validation error, never a silent override.
+    if all_findings:
+        computed_decision = compute_decision(
+            [{"severity": fd["fields"].get("severity", "")} for fd in all_findings]
+        )
+        verdict, _ = load_verdict(root)
+        authored_decision = verdict.get("decision")
+        if authored_decision and authored_decision != computed_decision:
+            errors.append((
+                "verdict.json", "-",
+                f"verdict.json declares decision {authored_decision!r} but the "
+                f"findings compute to {computed_decision!r} (any P0 is HOLD, "
+                "P1s with no P0 are FIX_THEN_SHIP, otherwise SHIP); the decision "
+                "is computed from findings and cannot be overridden - fix the "
+                "findings or fix verdict.json"
+            ))
 
     stats = {
         "total": len(all_findings),

--- a/skills/production-readiness-audit/SKILL.md
+++ b/skills/production-readiness-audit/SKILL.md
@@ -93,21 +93,33 @@ to act on later.
 ### Dashboard - always start it, do not ask
 
 Immediately after `audit_state.py init` succeeds (or the user confirms a state
-resume), start the dashboard yourself as a managed background Bash task. This
-is a default step of every audit run, not something the user opts into or
-requests:
+resume), start the dashboard. This is a default step of every audit run, not
+something the user opts into or requests:
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/readiness_dashboard.py" <root>
 ```
 
-Wait only for the printed URL line or an immediate error. Best-effort open the
-URL, report it to the user, and continue immediately to Stage 1.
+The command starts a detached server, waits for it to answer, prints its URL,
+and exits. It does not block, so run it as an ordinary foreground command - a
+managed background Bash task is no longer needed. It opens a browser itself
+where one is available. Report the URL to the user and continue immediately to
+Stage 1.
 
-If dashboard launch fails, tell the user it is unavailable and continue the audit
-anyway - launch failure is non-fatal and never blocks the audit. Do not wait for
-the dashboard process, use it as an audit agent, or change the selected
-parallel/sequential execution mode.
+The command is idempotent. A dashboard already serving this audit is reused
+rather than replaced, so running it twice is safe. A `PostToolUse` hook runs the
+same launcher when the audit state is written, which means the dashboard usually
+exists before you ask for it; the reuse rule makes that harmless.
+
+Exit code 0 means a dashboard is serving and the last line of output is its URL.
+Any other exit code means the dashboard is unavailable: tell the user, point at
+`.readiness-audit/dashboard.log`, and continue the audit anyway - launch failure
+is non-fatal and never blocks the audit. Do not use the dashboard as an audit
+agent, and do not change the selected parallel/sequential execution mode.
+
+The server outlives this session so that a reviewer can read the report after
+the audit ends. It closes itself after an hour with no reader, and
+`readiness_dashboard.py <root> --stop` closes it immediately.
 
 Offer to add `.readiness-audit/` to `.gitignore`.
 
@@ -195,17 +207,21 @@ Write the verdict first, as data, to `.readiness-audit/verdict.json`:
 
 ```json
 {
-  "decision": "HOLD",
   "headline": "Six confirmed blockers make this unsafe to deploy.",
   "summary": "Two are trivially exploitable from a browser... State here how much of this call rests on what you could not see."
 }
 ```
 
-`decision` is `SHIP`, `FIX_THEN_SHIP`, or `HOLD`. The rule is mechanical - any P0
-is HOLD, P1s alone are FIX THEN SHIP, neither is SHIP - but the sentence that
-matters most is the one in `summary` saying how much of the verdict rests on
-things you could not see. `headline` is one sentence a non-engineer reads first;
-it is the largest text on the dashboard.
+You write the prose. You do not write the decision: `SHIP`, `FIX_THEN_SHIP`, or
+`HOLD` is computed from the validated findings, because the rule is pure
+arithmetic - any P0 is HOLD, P1s alone are FIX THEN SHIP, neither is SHIP - and
+a counting rule applied by hand is a counting rule that eventually comes out
+different. A `decision` field that disagrees with the findings is a validation
+error, so leave it out.
+
+The sentence that matters most is the one in `summary` saying how much of the
+verdict rests on things you could not see. `headline` is one sentence a
+non-engineer reads first; it is the largest text on the dashboard.
 
 Then assemble:
 

--- a/skills/production-readiness-audit/references/finding-format.md
+++ b/skills/production-readiness-audit/references/finding-format.md
@@ -21,7 +21,12 @@ generates it from your JSON.
       "title": "Tenant identifier is read from the request body on order writes",
       "impact": "Any logged-in customer can read and change another company's orders by editing one value in the request.",
       "state": "CONFIRMED",
-      "severity": "P0",
+      "factors": {
+        "exposure": "authenticated",
+        "data_class": "financial",
+        "blast_radius": "systemic",
+        "compensating_control": "absent"
+      },
       "owner": "security",
       "cross_lens": ["backend", "database"],
       "evidence": ["src/orders/orders.service.ts:88"],
@@ -44,7 +49,7 @@ generates it from your JSON.
 | `title` | One line naming the problem. Required. |
 | `impact` | **What this costs a non-technical reader.** See below. Required. |
 | `state` | `CONFIRMED`, `NOT_FOUND`, or `UNVERIFIED`. Exactly one. |
-| `severity` | `P0`, `P1`, `P2`, or `P3`. |
+| `factors` | Object with `exposure`, `data_class`, `blast_radius`, `compensating_control`. A script derives `severity` from these four values - see Severity below. Do not set `severity` yourself. |
 | `owner` | Your lens, or the lens that owns it if you are cross-referencing. |
 | `cross_lens` | Array of other lenses this touches. `[]` if none. |
 | `evidence` | Array of `path/to/file.ts:120` strings for CONFIRMED. One entry per location - never a prose sentence. For NOT_FOUND, `["searched, not found in scope"]`. |
@@ -133,23 +138,40 @@ a real `NOT_FOUND`. Follow the ledger rather than your instinct here.
 
 ## Severity
 
-**P0 - production blocker.** A credible, exploitable path to catastrophic
-security compromise, major data loss, financial loss, regulatory exposure, or
-widespread outage, with no adequate compensating control. "Credible" means you
-can write the failure path down concretely - which is why `failure-path` is
-mandatory. If you cannot articulate it, it is not a P0. If a compensating
-control plausibly mitigates it, it is a P1.
+A lens does not choose `P0`-`P3`. It answers four factual questions in
+`factors`, and a script derives the severity from the answers. The same gap
+then gets the same rating on every run, whoever wrote it.
 
-**P1 - serious risk.** High likelihood or high impact against production
-reliability, security, scalability, or operability. Required controls that are
-absent within scope land here. So do implied RPO/RTO violations: nightly-only
-snapshots on a system whose criticality implies a one-hour RPO is a P1 even
-though nothing is technically broken.
+| Factor | Values |
+| --- | --- |
+| `exposure` | `internet`, `authenticated`, `internal`, `local` |
+| `data_class` | `secrets`, `pii`, `financial`, `business`, `none` |
+| `blast_radius` | `systemic`, `multi-tenant`, `single-tenant`, `single-user` |
+| `compensating_control` | `present`, `absent` |
 
-**P2/P3 - technical debt.** Shortcuts, TODOs, maintainability. No ego, no noise.
-If it would not change a decision, leave it out.
+The script scores each answer, sums the three factors, then subtracts for a
+present compensating control and floors the result at zero:
 
-Uncertainty never raises severity. A compensating control always lowers it.
+    exposure:        internet 3, authenticated 2, internal 1, local 0
+    data_class:      secrets 3, pii 3, financial 3, business 1, none 0
+    blast_radius:    systemic 3, multi-tenant 2, single-tenant 1, single-user 0
+    compensating_control present: subtract 2, total floored at 0
+
+    total >= 8   -> P0
+    total 6-7    -> P1
+    total 3-5    -> P2
+    total <= 2   -> P3
+
+An `UNVERIFIED` finding is never `P0`. Its rubric result is capped at `P1`,
+whatever the total.
+
+A finding that sets `severity` itself, instead of `factors`, is rejected by
+the validator. Answer the four questions honestly - do not pick values to
+land on a severity you already had in mind.
+
+`failure_path` and `compensating` are required whenever the factors score
+`P0`: write the concrete path to harm, and name the mitigating control or
+state `"none found"`.
 
 ## Proportionality
 

--- a/skills/production-readiness-dashboard/SKILL.md
+++ b/skills/production-readiness-dashboard/SKILL.md
@@ -19,6 +19,16 @@ path:
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/readiness_dashboard.py" <target-project-root>
 ```
 
-The server prints a local URL such as `http://127.0.0.1:<port>/`. Open that URL
-if the browser does not open automatically. Press Ctrl-C to stop a manually
-launched server.
+The command prints a local URL such as `http://127.0.0.1:<port>/` and exits. It
+opens that URL in a browser where one is available; open it yourself if not.
+
+The server runs detached, so it stays up after the session that started it and
+Ctrl-C does not reach it. It closes after an hour with no reader. To close it
+now:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/readiness_dashboard.py" <target-project-root> --stop
+```
+
+Running the command again while a dashboard is already serving that project
+reuses the running server instead of starting a second one.

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -1,0 +1,98 @@
+"""Tests for the dashboard's HTTP surface beyond the snapshot.
+
+These cover the two additions that changed what the dashboard is allowed to do:
+it now reports live lens progress, and it writes one kind of file.
+"""
+import json
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import progress  # noqa: E402
+import readiness_dashboard as dash  # noqa: E402
+
+
+class SnapshotProgressTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        (self.root / ".readiness-audit" / "findings").mkdir(parents=True)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_snapshot_carries_progress_for_every_lens(self):
+        progress.append_note(self.root, "security", "analyzing", "Reading the auth paths.")
+        snapshot = dash.build_snapshot(self.root)
+        self.assertIn("progress", snapshot)
+        self.assertEqual(snapshot["progress"]["security"]["events"][-1]["note"],
+                         "Reading the auth paths.")
+
+    def test_a_lens_that_said_nothing_has_no_invented_progress(self):
+        snapshot = dash.build_snapshot(self.root)
+        backend = snapshot["progress"]["backend"]
+        self.assertEqual(backend["events"], [])
+        self.assertEqual(backend["signal"], "no-signal")
+
+    def test_project_without_an_audit_still_reports_a_progress_key(self):
+        empty = Path(tempfile.mkdtemp(dir=self._tmp.name))
+        snapshot = dash.build_snapshot(empty)
+        self.assertEqual(snapshot["status"], "unavailable")
+        self.assertEqual(snapshot["progress"], {})
+
+
+class ServerRouteTests(unittest.TestCase):
+    """Runs a real server on a loopback port, in-process."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        (self.root / ".readiness-audit" / "findings").mkdir(parents=True)
+        self.addCleanup(self._tmp.cleanup)
+
+        self.server = dash.create_server(self.root, 0)
+        self.addCleanup(self.server.server_close)
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        self.addCleanup(self.server.shutdown)
+        self.url = dash.startup_url(self.server)
+
+    def _get(self, path):
+        with urllib.request.urlopen(self.url.rstrip("/") + path, timeout=10) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+
+    def test_ping_is_cheap_and_counts_as_activity(self):
+        self.server.last_activity -= 1000
+        status, payload = self._get("/api/ping")
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"ok": True})
+        self.assertLess(self.server.seconds_idle(), 5)
+
+    def test_unknown_route_is_not_found(self):
+        with self.assertRaises(urllib.error.HTTPError) as caught:
+            self._get("/api/nope")
+        self.assertEqual(caught.exception.code, 404)
+
+    def test_export_writes_a_directory_and_reports_its_files(self):
+        request = urllib.request.Request(self.url.rstrip("/") + "/api/export", method="POST")
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        self.assertTrue(payload["ok"], payload)
+        directory = Path(payload["directory"])
+        self.assertTrue(directory.is_dir())
+        self.assertIn("report.tex", payload["files"])
+        expected_parent = (self.root / ".readiness-audit" / "export").resolve()
+        self.assertEqual(directory.resolve().parent, expected_parent)
+
+    def test_export_rejects_any_other_post_route(self):
+        request = urllib.request.Request(self.url.rstrip("/") + "/api/snapshot", method="POST")
+        with self.assertRaises(urllib.error.HTTPError) as caught:
+            urllib.request.urlopen(request, timeout=10)
+        self.assertEqual(caught.exception.code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_launch.py
+++ b/tests/test_dashboard_launch.py
@@ -1,0 +1,229 @@
+"""Tests for the dashboard's launch protocol.
+
+The launch used to depend on a person or an agent reading a URL out of a log
+line. These tests cover the replacement: a handshake file, a health check that
+decides reuse, and a detached server process. The reuse decision is where the
+bugs live, so most of this is unit-level against a stubbed health check; one
+integration test exists because only a real spawn exercises the platform
+process flags.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import readiness_dashboard as dash  # noqa: E402
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "readiness_dashboard.py"
+
+
+class HandshakeFileTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_write_then_read_round_trip(self):
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        record = dash.read_handshake(self.root)
+        self.assertEqual(record["url"], "http://127.0.0.1:9/")
+        self.assertEqual(record["port"], 9)
+        self.assertEqual(record["pid"], os.getpid())
+        self.assertEqual(record["audit_root"], str(dash.audit_root_for(self.root)))
+
+    def test_write_creates_the_audit_directory(self):
+        self.assertFalse((self.root / ".readiness-audit").exists())
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        self.assertTrue((self.root / ".readiness-audit").is_dir())
+
+    def test_missing_file_reads_as_absent(self):
+        self.assertIsNone(dash.read_handshake(self.root))
+
+    def test_corrupt_json_reads_as_absent(self):
+        path = dash.handshake_path(self.root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        self.assertIsNone(dash.read_handshake(self.root))
+
+    def test_unknown_schema_reads_as_absent(self):
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        path = dash.handshake_path(self.root)
+        record = json.loads(path.read_text(encoding="utf-8"))
+        record["schema"] = dash.HANDSHAKE_SCHEMA + 99
+        path.write_text(json.dumps(record), encoding="utf-8")
+        self.assertIsNone(dash.read_handshake(self.root))
+
+    def test_incomplete_record_reads_as_absent(self):
+        path = dash.handshake_path(self.root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"schema": dash.HANDSHAKE_SCHEMA, "pid": 1}), encoding="utf-8")
+        self.assertIsNone(dash.read_handshake(self.root))
+
+
+class ReuseDecisionTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_healthy_record_is_reused(self):
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        with mock.patch.object(dash, "health_check", return_value=True):
+            self.assertIsNotNone(dash.find_running(self.root))
+
+    def test_unhealthy_record_is_not_reused(self):
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        with mock.patch.object(dash, "health_check", return_value=False):
+            self.assertIsNone(dash.find_running(self.root))
+
+    def test_record_for_another_audit_is_not_reused(self):
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        path = dash.handshake_path(self.root)
+        record = json.loads(path.read_text(encoding="utf-8"))
+        record["audit_root"] = str(Path(record["audit_root"]).parent / "somewhere-else")
+        path.write_text(json.dumps(record), encoding="utf-8")
+        with mock.patch.object(dash, "health_check", return_value=True) as health:
+            self.assertIsNone(dash.find_running(self.root))
+            health.assert_not_called()
+
+    def test_launch_reuses_instead_of_spawning(self):
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        with mock.patch.object(dash, "health_check", return_value=True), \
+                mock.patch.object(dash, "spawn_detached") as spawn:
+            record = dash.launch(self.root, open_in_browser=False)
+        spawn.assert_not_called()
+        self.assertEqual(record["url"], "http://127.0.0.1:9/")
+
+    def test_launch_reports_failure_when_no_handshake_appears(self):
+        with mock.patch.object(dash, "spawn_detached"), \
+                mock.patch.object(dash, "health_check", return_value=False):
+            self.assertIsNone(dash.launch(self.root, open_in_browser=False, timeout=0.2))
+
+
+class HealthCheckTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _response(self, payload):
+        body = json.dumps(payload).encode("utf-8")
+        response = mock.MagicMock()
+        response.status = 200
+        response.read.return_value = body
+        response.__enter__.return_value = response
+        return response
+
+    def test_matching_audit_root_is_healthy(self):
+        payload = {"auditRoot": str(dash.audit_root_for(self.root))}
+        with mock.patch.object(urllib.request, "urlopen", return_value=self._response(payload)):
+            self.assertTrue(dash.health_check("http://127.0.0.1:9/", dash.audit_root_for(self.root)))
+
+    def test_different_audit_root_is_not_healthy(self):
+        with mock.patch.object(urllib.request, "urlopen",
+                               return_value=self._response({"auditRoot": "/somewhere/else"})):
+            self.assertFalse(dash.health_check("http://127.0.0.1:9/", dash.audit_root_for(self.root)))
+
+    def test_connection_failure_is_not_healthy(self):
+        with mock.patch.object(urllib.request, "urlopen",
+                               side_effect=urllib.error.URLError("refused")):
+            self.assertFalse(dash.health_check("http://127.0.0.1:9/", dash.audit_root_for(self.root)))
+
+
+class StopTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_stale_record_is_deleted_and_nothing_is_signalled(self):
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        with mock.patch.object(dash, "health_check", return_value=False), \
+                mock.patch.object(os, "kill") as kill:
+            self.assertFalse(dash.stop(self.root))
+        kill.assert_not_called()
+        self.assertFalse(dash.handshake_path(self.root).exists())
+
+    def test_healthy_record_is_signalled(self):
+        dash.write_handshake(self.root, "http://127.0.0.1:9/", 9)
+        with mock.patch.object(dash, "health_check", return_value=True), \
+                mock.patch.object(os, "kill") as kill:
+            self.assertTrue(dash.stop(self.root))
+        kill.assert_called_once()
+        self.assertFalse(dash.handshake_path(self.root).exists())
+
+    def test_stop_without_a_record_is_not_an_error(self):
+        self.assertFalse(dash.stop(self.root))
+
+
+class BrowserTests(unittest.TestCase):
+    def test_remote_sessions_do_not_attempt_to_open_a_browser(self):
+        with mock.patch.dict(os.environ, {"CLAUDE_CODE_REMOTE": "1"}), \
+                mock.patch.object(dash.webbrowser, "open") as opener:
+            self.assertFalse(dash.open_browser("http://127.0.0.1:9/"))
+        opener.assert_not_called()
+
+    def test_a_failing_browser_never_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(dash.webbrowser, "open", side_effect=OSError("no display")):
+            self.assertFalse(dash.open_browser("http://127.0.0.1:9/"))
+
+
+class DetachedLaunchIntegrationTests(unittest.TestCase):
+    """One real spawn, because the platform process flags cannot be faked."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(self._terminate)
+
+    def _terminate(self):
+        record = dash.read_handshake(self.root)
+        if record:
+            try:
+                os.kill(int(record["pid"]), 9)
+            except OSError:
+                pass
+
+    def test_launcher_starts_a_server_that_answers(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(self.root), "--no-open"],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        url = result.stdout.strip().splitlines()[-1]
+        self.assertTrue(url.startswith("http://127.0.0.1:"), url)
+
+        record = dash.read_handshake(self.root)
+        self.assertIsNotNone(record)
+        self.assertEqual(record["url"], url)
+        self.assertTrue(dash.health_check(url, dash.audit_root_for(self.root), timeout=5))
+
+        with urllib.request.urlopen(url + "api/ping", timeout=5) as response:
+            self.assertEqual(json.loads(response.read().decode("utf-8")), {"ok": True})
+
+        again = subprocess.run(
+            [sys.executable, str(SCRIPT), str(self.root), "--no-open"],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(again.stdout.strip().splitlines()[-1], url,
+                         "a second launch must reuse the running server")
+
+        stopped = subprocess.run(
+            [sys.executable, str(SCRIPT), str(self.root), "--stop"],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(stopped.returncode, 0, stopped.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_skill_docs.py
+++ b/tests/test_dashboard_skill_docs.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 
@@ -16,9 +17,16 @@ class DashboardSkillDocumentationTests(unittest.TestCase):
     def test_audit_starts_dashboard_without_changing_parallel_default(self):
         audit_skill = (ROOT / "skills/production-readiness-audit/SKILL.md").read_text(encoding="utf-8")
         self.assertIn("readiness_dashboard.py", audit_skill)
-        self.assertIn("managed background Bash task", audit_skill)
+        self.assertIn("idempotent", audit_skill)
         self.assertIn("Parallel is the default", audit_skill)
         self.assertIn("non-fatal", audit_skill)
+
+    def test_launch_hook_is_registered_for_bash_tool_use(self):
+        hooks = json.loads((ROOT / "hooks/hooks.json").read_text(encoding="utf-8"))
+        matchers = hooks["hooks"]["PostToolUse"]
+        commands = [hook["command"] for entry in matchers for hook in entry["hooks"]]
+        self.assertTrue(any("launch_dashboard_hook.py" in command for command in commands))
+        self.assertTrue(any(entry.get("matcher") == "Bash" for entry in matchers))
 
     def test_readme_explains_automatic_and_manual_dashboard_use(self):
         readme = (ROOT / "README.md").read_text(encoding="utf-8")

--- a/tests/test_export_report.py
+++ b/tests/test_export_report.py
@@ -1,0 +1,349 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts.export_report import export, latex_escape
+from scripts.finding_store import FINDING_SCHEMA
+
+# Severity is derived from `factors` (see scripts/severity.py), not authored
+# directly, so each nominal severity used by these fixtures maps to a rubric
+# combination that scores into that band. Values chosen comfortably inside
+# each band's threshold so an unrelated change to the rubric's boundaries is
+# unlikely to shift these into a different severity.
+_SEVERITY_FACTORS = {
+    "P0": {"exposure": "internet", "data_class": "secrets",
+           "blast_radius": "systemic", "compensating_control": "absent"},
+    "P1": {"exposure": "authenticated", "data_class": "pii",
+           "blast_radius": "multi-tenant", "compensating_control": "absent"},
+    "P2": {"exposure": "internal", "data_class": "business",
+           "blast_radius": "single-tenant", "compensating_control": "absent"},
+    "P3": {"exposure": "local", "data_class": "none",
+           "blast_radius": "single-user", "compensating_control": "absent"},
+}
+
+
+def _write_state(audit: Path, **overrides):
+    state = {"stage": "3-lenses", "stage_status": "in_progress",
+              "lenses_to_run": [], "lenses_skipped": {}}
+    state.update(overrides)
+    audit.mkdir(parents=True, exist_ok=True)
+    (audit / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+
+def _write_findings(audit: Path, lens: str, findings: list[dict]):
+    (audit / "findings").mkdir(parents=True, exist_ok=True)
+    (audit / "findings" / f"{lens}.json").write_text(
+        json.dumps({"schema": FINDING_SCHEMA, "lens": lens, "findings": findings}),
+        encoding="utf-8")
+
+
+def _finding(**overrides):
+    severity = overrides.pop("severity", "P0")
+    base = {
+        "id": "PRA-SEC-001",
+        "title": "Tenant id is read from the request body",
+        "impact": "Any logged-in customer can read another company's orders.",
+        "state": "CONFIRMED",
+        "factors": dict(_SEVERITY_FACTORS[severity]),
+        "evidence": ["src/orders/orders_service.ts:88"],
+        "failure_path": "The controller trusts a client-supplied tenant id.",
+        "compensating": "none found",
+        "fix": "Derive the tenant from the session.",
+    }
+    base.update(overrides)
+    return base
+
+
+def _no_compiler():
+    """Force the "no TeX compiler on PATH" branch, so tests never depend on
+    whatever happens to be installed on the machine running them."""
+    return mock.patch("scripts.export_report._find_tex_compiler", return_value=None)
+
+
+class LatexEscapeTests(unittest.TestCase):
+    """Every character LaTeX treats as syntax must come out escaped. A
+    mangled file path in a security finding is worse than no finding, so
+    these are exact-match, one character at a time."""
+
+    def test_none_and_empty_string_escape_to_empty_string(self):
+        self.assertEqual(latex_escape(None), "")
+        self.assertEqual(latex_escape(""), "")
+
+    def test_backslash(self):
+        self.assertEqual(latex_escape("\\"), r"\textbackslash{}")
+
+    def test_open_brace(self):
+        self.assertEqual(latex_escape("{"), r"\{")
+
+    def test_close_brace(self):
+        self.assertEqual(latex_escape("}"), r"\}")
+
+    def test_dollar(self):
+        self.assertEqual(latex_escape("$"), r"\$")
+
+    def test_percent(self):
+        self.assertEqual(latex_escape("%"), r"\%")
+
+    def test_ampersand(self):
+        self.assertEqual(latex_escape("&"), r"\&")
+
+    def test_hash(self):
+        self.assertEqual(latex_escape("#"), r"\#")
+
+    def test_underscore(self):
+        self.assertEqual(latex_escape("_"), r"\_")
+
+    def test_caret(self):
+        self.assertEqual(latex_escape("^"), r"\textasciicircum{}")
+
+    def test_tilde(self):
+        self.assertEqual(latex_escape("~"), r"\textasciitilde{}")
+
+    def test_file_path_with_underscores_survives_intact(self):
+        self.assertEqual(
+            latex_escape("src/orders_service/handler_v2.py"),
+            r"src/orders\_service/handler\_v2.py")
+
+    def test_every_special_character_together_in_one_string(self):
+        raw = "100% & $5 #1 ~caret^ back\\slash {brace}_underscore"
+        expected = (
+            r"100\% \& \$5 \#1 \textasciitilde{}caret\textasciicircum{} "
+            r"back\textbackslash{}slash \{brace\}\_underscore"
+        )
+        self.assertEqual(latex_escape(raw), expected)
+
+    def test_plain_text_with_no_special_characters_is_unchanged(self):
+        self.assertEqual(latex_escape("nothing special here"), "nothing special here")
+
+    def test_non_string_values_are_stringified_first(self):
+        self.assertEqual(latex_escape(42), "42")
+
+
+class ExportOutputTests(unittest.TestCase):
+    def _root(self):
+        return Path(tempfile.mkdtemp())
+
+    def test_missing_readiness_audit_directory_does_not_crash(self):
+        root = self._root()
+        self.assertFalse((root / ".readiness-audit").exists())
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        self.assertTrue(out_dir.is_dir())
+        self.assertTrue((out_dir / "report.tex").exists())
+        for lens in ("security", "backend", "frontend", "devops", "qa", "database", "ai-security"):
+            self.assertTrue((out_dir / f"report-{lens}.tex").exists())
+        # No report.md source existed, so none should have been copied.
+        self.assertFalse((out_dir / "report.md").exists())
+        # No compiler was available, so no PDF either - and that must not
+        # have been treated as an error.
+        self.assertFalse((out_dir / "report.pdf").exists())
+
+    def test_missing_directory_output_is_placed_under_readiness_audit_export(self):
+        root = self._root()
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        self.assertEqual(out_dir.parent.parent, root.resolve() / ".readiness-audit")
+        self.assertEqual(out_dir.parent.name, "export")
+        self.assertTrue(out_dir.name.startswith("nogit-") or "-" in out_dir.name)
+
+    def test_output_directory_uses_short_git_ref_and_utc_timestamp(self):
+        root = self._root()
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        # This repo checkout is not a git repository under a bare temp dir,
+        # so the ref must fall back to "nogit", and the timestamp must be
+        # 8 digits, "T", 6 digits, "Z".
+        ref, _, timestamp = out_dir.name.partition("-")
+        self.assertEqual(ref, "nogit")
+        self.assertRegex(timestamp, r"^\d{8}T\d{6}Z(-\d+)?$")
+
+    def test_two_exports_never_collide_or_overwrite(self):
+        root = self._root()
+
+        with _no_compiler():
+            first = export(root)
+            second = export(root)
+
+        self.assertNotEqual(first, second)
+        self.assertTrue(first.is_dir())
+        self.assertTrue(second.is_dir())
+        self.assertTrue((first / "report.tex").exists())
+        self.assertTrue((second / "report.tex").exists())
+
+    def test_report_md_is_copied_when_present(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        _write_state(audit, stage_status="complete")
+        (audit / "report.md").write_text("# Production Readiness Audit\n", encoding="utf-8")
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        self.assertEqual((out_dir / "report.md").read_text(encoding="utf-8"),
+                         "# Production Readiness Audit\n")
+
+    def test_no_tex_compiler_present_exits_cleanly_and_keeps_tex_files(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        _write_state(audit, stage_status="complete")
+
+        with _no_compiler(), mock.patch("builtins.print") as printed:
+            out_dir = export(root)
+
+        self.assertTrue((out_dir / "report.tex").exists())
+        self.assertFalse((out_dir / "report.pdf").exists())
+        # Exactly one explanatory line, telling the user how to compile it
+        # themselves - missing TeX is never treated as an error.
+        messages = [call.args[0] for call in printed.call_args_list]
+        self.assertEqual(len(messages), 1)
+        self.assertIn("tectonic", messages[0])
+        self.assertIn("pdflatex", messages[0])
+        self.assertIn(str(out_dir), messages[0])
+
+    def test_compiler_is_invoked_when_one_is_found_on_path(self):
+        root = self._root()
+        _write_state(root / ".readiness-audit", stage_status="complete")
+
+        with mock.patch("scripts.export_report._find_tex_compiler",
+                        return_value=("tectonic", "/usr/bin/tectonic")), \
+             mock.patch("scripts.export_report._compile_pdf", return_value=True) as compiled:
+            export(root)
+
+        compiled.assert_called_once()
+        self.assertEqual(compiled.call_args[0][0], ("tectonic", "/usr/bin/tectonic"))
+
+
+class IncompleteAuditBannerTests(unittest.TestCase):
+    def _root(self):
+        return Path(tempfile.mkdtemp())
+
+    def test_incomplete_audit_carries_a_banner_naming_the_stage(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        _write_state(audit, stage="3-lenses", stage_status="in_progress",
+                     lenses_to_run=["security", "backend"])
+        _write_findings(audit, "security", [_finding()])
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        text = (out_dir / "report.tex").read_text(encoding="utf-8")
+        self.assertIn("AUDIT INCOMPLETE", text)
+        self.assertIn("3-lenses", text)
+        # Backend is running/waiting and every other unrun lens has not
+        # reported; the banner must name them.
+        self.assertIn("Frontend", text)
+        self.assertIn("Backend", text)
+
+    def test_complete_audit_carries_no_incomplete_banner(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        _write_state(audit, stage="5-report", stage_status="complete")
+        for lens in ("security", "backend", "frontend", "devops", "qa", "database", "ai-security"):
+            _write_findings(audit, lens, [])
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        text = (out_dir / "report.tex").read_text(encoding="utf-8")
+        self.assertNotIn("AUDIT INCOMPLETE", text)
+
+    def test_incomplete_banner_appears_on_every_per_lens_document_too(self):
+        """An incomplete audit must never look complete, no matter which
+        document a reviewer opens."""
+        root = self._root()
+        _write_state(root / ".readiness-audit", stage="2-evidence", stage_status="in_progress")
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        for lens in ("security", "backend", "frontend", "devops", "qa", "database", "ai-security"):
+            text = (out_dir / f"report-{lens}.tex").read_text(encoding="utf-8")
+            self.assertIn("AUDIT INCOMPLETE", text, f"missing banner in report-{lens}.tex")
+
+
+class PerLensDocumentTests(unittest.TestCase):
+    def _root(self):
+        return Path(tempfile.mkdtemp())
+
+    def test_per_lens_document_contains_only_that_lens_findings(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        _write_state(audit, stage_status="complete")
+        _write_findings(audit, "security", [
+            _finding(id="PRA-SEC-001", title="Security finding one")])
+        _write_findings(audit, "backend", [
+            _finding(id="PRA-BE-001", title="Backend finding one", severity="P1")])
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        security_doc = (out_dir / "report-security.tex").read_text(encoding="utf-8")
+        backend_doc = (out_dir / "report-backend.tex").read_text(encoding="utf-8")
+
+        self.assertIn("PRA-SEC-001", security_doc)
+        self.assertNotIn("PRA-BE-001", security_doc)
+
+        self.assertIn("PRA-BE-001", backend_doc)
+        self.assertNotIn("PRA-SEC-001", backend_doc)
+
+    def test_combined_document_contains_every_lens_finding(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        _write_state(audit, stage_status="complete")
+        _write_findings(audit, "security", [_finding(id="PRA-SEC-001")])
+        _write_findings(audit, "database", [
+            _finding(id="PRA-DB-001", title="Missing PITR", severity="P0")])
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        combined = (out_dir / "report.tex").read_text(encoding="utf-8")
+        self.assertIn("PRA-SEC-001", combined)
+        self.assertIn("PRA-DB-001", combined)
+
+    def test_combined_document_appendix_lists_every_unverified_finding(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        _write_state(audit, stage_status="complete")
+        _write_findings(audit, "security", [
+            _finding(id="PRA-SEC-002", state="UNVERIFIED", resolve="Check the console.")])
+        _write_findings(audit, "qa", [
+            _finding(id="PRA-QA-001", title="Untested checkout path",
+                    state="UNVERIFIED", severity="P1", resolve="Run the checkout suite.")])
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        combined = (out_dir / "report.tex").read_text(encoding="utf-8")
+        appendix = combined.split(r"\appendix", 1)[1]
+        self.assertIn("PRA-SEC-002", appendix)
+        self.assertIn("PRA-QA-001", appendix)
+
+    def test_evidence_list_items_render_in_a_verbatim_block_not_escaped(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        _write_state(audit, stage_status="complete")
+        _write_findings(audit, "security", [
+            _finding(id="PRA-SEC-003", evidence=["src/db_client.py:42 -> query % 100"])])
+
+        with _no_compiler():
+            out_dir = export(root)
+
+        combined = (out_dir / "report.tex").read_text(encoding="utf-8")
+        self.assertIn(r"\begin{verbatim}", combined)
+        # Verbatim content is not escaped: the raw evidence string must
+        # appear untouched, backslash-percent-and-all.
+        self.assertIn("src/db_client.py:42 -> query % 100", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,200 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from scripts.progress import (
+    LENSES,
+    PHASES,
+    SILENCE_THRESHOLD_SECONDS,
+    append_note,
+    read_progress,
+)
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "progress.py"
+
+
+def make_root() -> Path:
+    return Path(tempfile.mkdtemp())
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def progress_file(root: Path, lens: str) -> Path:
+    return root / ".readiness-audit" / "progress" / f"{lens}.jsonl"
+
+
+class NoteCommandTests(unittest.TestCase):
+    def test_valid_note_is_appended_and_readable(self):
+        root = make_root()
+
+        result = run_cli("note", str(root), "security", "started", "reading auth code")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        path = progress_file(root, "security")
+        self.assertTrue(path.exists())
+        lines = path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(lines), 1)
+        event = json.loads(lines[0])
+        self.assertEqual(event["lens"], "security")
+        self.assertEqual(event["phase"], "started")
+        self.assertEqual(event["note"], "reading auth code")
+        self.assertIn("ts", event)
+
+        snapshot = read_progress(root)
+        self.assertEqual(snapshot["security"]["latest_phase"], "started")
+        self.assertEqual(len(snapshot["security"]["events"]), 1)
+
+    def test_note_is_optional(self):
+        root = make_root()
+
+        result = run_cli("note", str(root), "backend", "done")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = json.loads(progress_file(root, "backend").read_text(encoding="utf-8").strip())
+        self.assertIsNone(event["note"])
+
+    def test_unknown_lens_is_rejected_with_nonzero_exit(self):
+        root = make_root()
+
+        result = run_cli("note", str(root), "not-a-lens", "started")
+
+        self.assertNotEqual(result.returncode, 0)
+        for lens in LENSES:
+            self.assertIn(lens, result.stderr)
+        self.assertFalse(progress_file(root, "not-a-lens").exists())
+
+    def test_unknown_phase_is_rejected_with_nonzero_exit(self):
+        root = make_root()
+
+        result = run_cli("note", str(root), "security", "not-a-phase")
+
+        self.assertNotEqual(result.returncode, 0)
+        for phase in PHASES:
+            self.assertIn(phase, result.stderr)
+        self.assertFalse(progress_file(root, "security").exists())
+
+    def test_rejected_note_raises_value_error_via_import(self):
+        root = make_root()
+
+        with self.assertRaises(ValueError):
+            append_note(root, "security", "bogus-phase", None)
+        with self.assertRaises(ValueError):
+            append_note(root, "bogus-lens", "started", None)
+
+
+class TwoLensesAppendingTests(unittest.TestCase):
+    def test_two_lenses_do_not_interfere(self):
+        root = make_root()
+
+        append_note(root, "security", "started", "sec note one")
+        append_note(root, "database", "started", "db note one")
+        append_note(root, "security", "analyzing", "sec note two")
+        append_note(root, "database", "done", "db note two")
+
+        sec_lines = progress_file(root, "security").read_text(encoding="utf-8").splitlines()
+        db_lines = progress_file(root, "database").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(sec_lines), 2)
+        self.assertEqual(len(db_lines), 2)
+
+        snapshot = read_progress(root)
+        self.assertEqual([e["phase"] for e in snapshot["security"]["events"]], ["started", "analyzing"])
+        self.assertEqual([e["phase"] for e in snapshot["database"]["events"]], ["started", "done"])
+        self.assertTrue(all(e["lens"] == "security" for e in snapshot["security"]["events"]))
+        self.assertTrue(all(e["lens"] == "database" for e in snapshot["database"]["events"]))
+
+
+class ReadProgressTests(unittest.TestCase):
+    def test_lens_with_zero_events_has_no_fabricated_progress(self):
+        root = make_root()
+
+        snapshot = read_progress(root)
+
+        self.assertEqual(set(snapshot.keys()), set(LENSES))
+        for lens in LENSES:
+            entry = snapshot[lens]
+            self.assertEqual(entry["events"], [])
+            self.assertIsNone(entry["latest_phase"])
+            self.assertIsNone(entry["latest_ts"])
+            self.assertIsNone(entry["seconds_since_latest"])
+            self.assertEqual(entry["signal"], "no-signal")
+
+    def test_recent_event_is_not_no_signal(self):
+        root = make_root()
+        append_note(root, "qa", "analyzing", None)
+
+        snapshot = read_progress(root)
+
+        self.assertNotEqual(snapshot["qa"]["signal"], "no-signal")
+        self.assertLess(snapshot["qa"]["seconds_since_latest"], 5)
+
+    def test_stale_event_below_done_reports_no_signal(self):
+        root = make_root()
+        path = progress_file(root, "frontend")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        stale_ts = (datetime.now(timezone.utc) - timedelta(seconds=SILENCE_THRESHOLD_SECONDS + 30)).isoformat()
+        event = {"ts": stale_ts, "lens": "frontend", "phase": "analyzing", "note": None}
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event) + "\n")
+
+        snapshot = read_progress(root)
+
+        self.assertEqual(snapshot["frontend"]["signal"], "no-signal")
+        self.assertGreater(snapshot["frontend"]["seconds_since_latest"], SILENCE_THRESHOLD_SECONDS)
+
+    def test_stale_done_event_is_not_no_signal(self):
+        root = make_root()
+        path = progress_file(root, "devops")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        stale_ts = (datetime.now(timezone.utc) - timedelta(seconds=SILENCE_THRESHOLD_SECONDS + 30)).isoformat()
+        event = {"ts": stale_ts, "lens": "devops", "phase": "done", "note": None}
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event) + "\n")
+
+        snapshot = read_progress(root)
+
+        self.assertEqual(snapshot["devops"]["latest_phase"], "done")
+        self.assertNotEqual(snapshot["devops"]["signal"], "no-signal")
+
+    def test_corrupt_line_is_skipped_not_fatal(self):
+        root = make_root()
+        append_note(root, "ai-security", "started", "first")
+        path = progress_file(root, "ai-security")
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("{not valid json\n")
+            fh.write("\n")
+        append_note(root, "ai-security", "done", "last")
+
+        snapshot = read_progress(root)
+
+        phases = [e["phase"] for e in snapshot["ai-security"]["events"]]
+        self.assertEqual(phases, ["started", "done"])
+        self.assertEqual(snapshot["ai-security"]["latest_phase"], "done")
+
+
+class ReadCommandTests(unittest.TestCase):
+    def test_read_command_prints_json_for_every_lens(self):
+        root = make_root()
+        append_note(root, "security", "started", None)
+
+        result = run_cli("read", str(root))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(set(payload.keys()), set(LENSES))
+        self.assertEqual(payload["security"]["latest_phase"], "started")
+        self.assertEqual(payload["backend"]["events"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_readiness_dashboard.py
+++ b/tests/test_readiness_dashboard.py
@@ -5,22 +5,40 @@ import threading
 import unittest
 from pathlib import Path
 
+from scripts.finding_store import FINDING_SCHEMA
 from scripts.readiness_dashboard import DASHBOARD_HTML, build_snapshot, create_server, startup_url
 
 
 def write_findings(audit, lens, findings):
     (audit / "findings").mkdir(parents=True, exist_ok=True)
     (audit / "findings" / f"{lens}.json").write_text(
-        json.dumps({"schema": 1, "lens": lens, "findings": findings}), encoding="utf-8")
+        json.dumps({"schema": FINDING_SCHEMA, "lens": lens, "findings": findings}),
+        encoding="utf-8")
+
+
+# A lens supplies factors, not a severity. These sets are chosen so the rubric
+# in severity.py produces each band, which keeps the tests readable: they still
+# say "give me a P0" while exercising the real derivation.
+FACTORS_FOR_SEVERITY = {
+    "P0": {"exposure": "internet", "data_class": "secrets",
+           "blast_radius": "systemic", "compensating_control": "absent"},
+    "P1": {"exposure": "internet", "data_class": "business",
+           "blast_radius": "multi-tenant", "compensating_control": "absent"},
+    "P2": {"exposure": "internal", "data_class": "business",
+           "blast_radius": "single-tenant", "compensating_control": "absent"},
+    "P3": {"exposure": "local", "data_class": "none",
+           "blast_radius": "single-user", "compensating_control": "absent"},
+}
 
 
 def finding(**overrides):
+    severity = overrides.pop("severity", "P0")
     base = {
         "id": "PRA-SEC-001",
         "title": "Tenant id is read from the request body",
         "impact": "Any logged-in customer can read another company's orders.",
         "state": "CONFIRMED",
-        "severity": "P0",
+        "factors": dict(FACTORS_FOR_SEVERITY[severity]),
         "evidence": ["src/orders/orders.service.ts:88"],
         "failure_path": "The controller trusts a client-supplied tenant id.",
         "compensating": "none found",
@@ -148,20 +166,43 @@ class SnapshotTests(unittest.TestCase):
 
         self.assertEqual(ids, ["PRA-SEC-002", "PRA-SEC-005", "PRA-SEC-009"])
 
-    def test_verdict_is_read_from_data_not_from_prose(self):
+    def test_verdict_prose_is_authored_but_the_decision_is_computed(self):
         root = self._root()
         audit = root / ".readiness-audit"
         self._write_state(audit, stage_status="complete")
         (audit / "report.md").write_text("## Executive Verdict\n\n**SHIP**\n", encoding="utf-8")
+        write_findings(audit, "security", [finding(severity="P0")])
         (audit / "verdict.json").write_text(json.dumps({
             "decision": "HOLD",
             "headline": "Two blockers make this unsafe to deploy.",
         }), encoding="utf-8")
 
-        verdict = build_snapshot(root)["verdict"]
+        snapshot = build_snapshot(root)
 
-        self.assertEqual(verdict["decision"], "HOLD")
-        self.assertEqual(verdict["headline"], "Two blockers make this unsafe to deploy.")
+        self.assertEqual(snapshot["verdict"]["decision"], "HOLD")
+        self.assertEqual(snapshot["verdict"]["headline"],
+                         "Two blockers make this unsafe to deploy.")
+        self.assertEqual(snapshot["errors"], [])
+
+    def test_an_authored_decision_that_disagrees_with_the_findings_is_reported(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        self._write_state(audit, stage_status="complete")
+        write_findings(audit, "security", [finding(severity="P0")])
+        (audit / "verdict.json").write_text(json.dumps({"decision": "SHIP"}), encoding="utf-8")
+
+        snapshot = build_snapshot(root)
+
+        self.assertEqual(snapshot["verdict"]["decision"], "HOLD")
+        self.assertTrue(any("disagrees with the findings" in e for e in snapshot["errors"]))
+
+    def test_a_running_audit_shows_no_decision_at_all(self):
+        root = self._root()
+        audit = root / ".readiness-audit"
+        self._write_state(audit)
+        write_findings(audit, "security", [finding(severity="P2")])
+
+        self.assertIsNone(build_snapshot(root)["verdict"]["decision"])
 
     def test_unknown_verdict_decision_is_reported_not_guessed(self):
         root = self._root()

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -1,0 +1,537 @@
+"""
+Tests for deterministic severity and the computed go/no-go decision.
+
+Severity used to be a lens's judgement call, so the same gap could be graded
+P1 one run and P3 the next. It is now a pure function of four closed factors
+(scripts/severity.py). The go/no-go decision was the same kind of problem -
+the model wrote verdict.json by hand even though the rule was always
+mechanical - so it is now computed from the validated findings too
+(scripts/validate_findings.py and scripts/assemble_report.py).
+
+This file covers all three: the rubric in severity.py, the validator's
+rejection of hand-set severity and invalid/missing factors, and the three
+decision outcomes including the disagreement-with-verdict.json error.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.severity import (
+    FACTOR_KEYS,
+    FACTORS,
+    FactorError,
+    compute_severity,
+    score_factors,
+    severity_for_score,
+    validate_factors,
+)
+from scripts.finding_store import FINDING_SCHEMA, compute_decision, load_lens, normalise_finding, FindingError
+from scripts.validate_findings import validate
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def factors(exposure="internal", data_class="none", blast_radius="single-user",
+            compensating_control="absent"):
+    return {
+        "exposure": exposure,
+        "data_class": data_class,
+        "blast_radius": blast_radius,
+        "compensating_control": compensating_control,
+    }
+
+
+def write_json(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def base_finding(**overrides) -> dict:
+    """A finding that passes every validator rule except what a test overrides."""
+    finding = {
+        "id": "PRA-SEC-001",
+        "title": "Tenant identifier is read from the request body on order writes",
+        "impact": "Any logged-in customer can read and change another company's orders.",
+        "state": "CONFIRMED",
+        "owner": "security",
+        "cross_lens": [],
+        "evidence": ["src/orders/orders.service.ts:88"],
+        "probe": None,
+        "failure_path": "OrdersController accepts tenantId in the POST body.",
+        "compensating": "none found",
+        "fix": "Derive tenantId from the authenticated principal.",
+        "resolve": None,
+        "see": None,
+        "factors": factors(exposure="internet", data_class="pii",
+                            blast_radius="multi-tenant", compensating_control="absent"),
+    }
+    finding.update(overrides)
+    return finding
+
+
+def write_lens_file(root: Path, lens: str, findings: list) -> Path:
+    path = root / ".readiness-audit" / "findings" / f"{lens}.json"
+    write_json(path, {"schema": FINDING_SCHEMA, "lens": lens, "findings": findings})
+    return path
+
+
+def write_ledger(root: Path, controls: dict | None = None) -> None:
+    write_json(root / ".readiness-audit" / "evidence" / "absence-ledger.json",
+               {"controls": controls or {}})
+
+
+def write_verdict(root: Path, decision: str | None = None) -> None:
+    payload = {}
+    if decision is not None:
+        payload["decision"] = decision
+    write_json(root / ".readiness-audit" / "verdict.json", payload)
+
+
+class TempRoot:
+    """A throwaway .readiness-audit/ tree, with the ledger pre-seeded so
+    validate() never fails for reasons unrelated to what a test checks."""
+
+    def __enter__(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        write_ledger(self.root)
+        return self.root
+
+    def __exit__(self, *exc):
+        self._tmp.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# rubric: boundaries, subtraction, floor, UNVERIFIED cap
+# ---------------------------------------------------------------------------
+
+class SeverityForScoreBoundaryTests(unittest.TestCase):
+    """Every threshold, both sides, expressed directly against the totals in
+    the spec: total>=8 P0, 6-7 P1, 3-5 P2, <=2 P3."""
+
+    def test_seven_is_p1_not_p0(self):
+        self.assertEqual(severity_for_score(7), "P1")
+
+    def test_eight_is_p0(self):
+        self.assertEqual(severity_for_score(8), "P0")
+
+    def test_five_is_p2_not_p1(self):
+        self.assertEqual(severity_for_score(5), "P2")
+
+    def test_six_is_p1(self):
+        self.assertEqual(severity_for_score(6), "P1")
+
+    def test_two_is_p3_not_p2(self):
+        self.assertEqual(severity_for_score(2), "P3")
+
+    def test_three_is_p2(self):
+        self.assertEqual(severity_for_score(3), "P2")
+
+    def test_zero_is_p3(self):
+        self.assertEqual(severity_for_score(0), "P3")
+
+    def test_maximum_possible_total_is_p0(self):
+        # internet(3) + secrets/pii/financial(3) + systemic(3) = 9
+        self.assertEqual(severity_for_score(9), "P0")
+
+
+class ScoreFactorsTests(unittest.TestCase):
+    def test_sums_the_three_axes(self):
+        f = factors(exposure="internet", data_class="secrets",
+                     blast_radius="systemic", compensating_control="absent")
+        self.assertEqual(score_factors(f), 9)
+
+    def test_compensating_control_present_subtracts_two(self):
+        f = factors(exposure="internet", data_class="secrets",
+                     blast_radius="systemic", compensating_control="present")
+        self.assertEqual(score_factors(f), 7)
+
+    def test_compensating_control_absent_leaves_total_unchanged(self):
+        f = factors(exposure="internet", data_class="secrets",
+                     blast_radius="systemic", compensating_control="absent")
+        self.assertEqual(score_factors(f), 9)
+
+    def test_floor_at_zero(self):
+        # local(0) + none(0) + single-user(0), then subtract 2 -> floored to 0
+        f = factors(exposure="local", data_class="none",
+                     blast_radius="single-user", compensating_control="present")
+        self.assertEqual(score_factors(f), 0)
+
+    def test_lowest_score_is_p3(self):
+        f = factors(exposure="local", data_class="none",
+                     blast_radius="single-user", compensating_control="present")
+        self.assertEqual(compute_severity(f, "CONFIRMED"), "P3")
+
+    def test_all_factor_point_tables_agree_with_the_published_rubric(self):
+        self.assertEqual(FACTORS["exposure"],
+                          {"internet": 3, "authenticated": 2, "internal": 1, "local": 0})
+        self.assertEqual(FACTORS["data_class"],
+                          {"secrets": 3, "pii": 3, "financial": 3, "business": 1, "none": 0})
+        self.assertEqual(FACTORS["blast_radius"],
+                          {"systemic": 3, "multi-tenant": 2, "single-tenant": 1, "single-user": 0})
+        self.assertEqual(set(FACTOR_KEYS),
+                          {"exposure", "data_class", "blast_radius", "compensating_control"})
+
+
+class ComputeSeverityUnverifiedCapTests(unittest.TestCase):
+    """A finding whose evidence state is UNVERIFIED can never be P0."""
+
+    def test_unverified_finding_that_would_score_p0_is_capped_to_p1(self):
+        f = factors(exposure="internet", data_class="secrets",
+                     blast_radius="systemic", compensating_control="absent")
+        self.assertEqual(score_factors(f), 9)  # would be P0 if CONFIRMED
+        self.assertEqual(compute_severity(f, "UNVERIFIED"), "P1")
+
+    def test_confirmed_finding_with_the_same_factors_is_p0(self):
+        f = factors(exposure="internet", data_class="secrets",
+                     blast_radius="systemic", compensating_control="absent")
+        self.assertEqual(compute_severity(f, "CONFIRMED"), "P0")
+
+    def test_not_found_finding_is_not_capped(self):
+        # the cap is specific to UNVERIFIED; NOT_FOUND is an established absence
+        f = factors(exposure="internet", data_class="secrets",
+                     blast_radius="systemic", compensating_control="absent")
+        self.assertEqual(compute_severity(f, "NOT_FOUND"), "P0")
+
+    def test_unverified_finding_below_p0_is_unaffected(self):
+        f = factors(exposure="authenticated", data_class="business",
+                     blast_radius="single-tenant", compensating_control="absent")
+        self.assertEqual(severity_for_score(score_factors(f)), "P2")
+        self.assertEqual(compute_severity(f, "UNVERIFIED"), "P2")
+
+    def test_state_matching_is_case_and_whitespace_insensitive(self):
+        f = factors(exposure="internet", data_class="secrets",
+                     blast_radius="systemic", compensating_control="absent")
+        self.assertEqual(compute_severity(f, " unverified "), "P1")
+
+
+# ---------------------------------------------------------------------------
+# validate_factors: missing factors, each invalid enum value
+# ---------------------------------------------------------------------------
+
+class ValidateFactorsTests(unittest.TestCase):
+    def test_valid_factors_produce_no_errors(self):
+        self.assertEqual(validate_factors(factors()), [])
+
+    def test_missing_factors_object_is_one_error_naming_all_keys(self):
+        errors = validate_factors(None)
+        self.assertEqual(len(errors), 1)
+        for key in FACTOR_KEYS:
+            self.assertIn(key, errors[0])
+
+    def test_factors_that_is_not_an_object_is_rejected(self):
+        errors = validate_factors("internet")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("factors", errors[0])
+
+    def test_missing_exposure_key_names_exposure_and_lists_allowed_values(self):
+        bad = factors()
+        del bad["exposure"]
+        errors = validate_factors(bad)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("factors.exposure", errors[0])
+        for value in ("internet", "authenticated", "internal", "local"):
+            self.assertIn(value, errors[0])
+
+    def test_invalid_exposure_value_names_the_key_and_the_bad_value(self):
+        errors = validate_factors(factors(exposure="offsite"))
+        self.assertEqual(len(errors), 1)
+        self.assertIn("factors.exposure", errors[0])
+        self.assertIn("offsite", errors[0])
+
+    def test_invalid_data_class_value_names_the_key_and_lists_allowed_values(self):
+        errors = validate_factors(factors(data_class="health"))
+        self.assertEqual(len(errors), 1)
+        self.assertIn("factors.data_class", errors[0])
+        for value in ("secrets", "pii", "financial", "business", "none"):
+            self.assertIn(value, errors[0])
+
+    def test_invalid_blast_radius_value_names_the_key_and_lists_allowed_values(self):
+        errors = validate_factors(factors(blast_radius="global"))
+        self.assertEqual(len(errors), 1)
+        self.assertIn("factors.blast_radius", errors[0])
+        for value in ("systemic", "multi-tenant", "single-tenant", "single-user"):
+            self.assertIn(value, errors[0])
+
+    def test_invalid_compensating_control_value_names_the_key_and_lists_allowed_values(self):
+        errors = validate_factors(factors(compensating_control="partial"))
+        self.assertEqual(len(errors), 1)
+        self.assertIn("factors.compensating_control", errors[0])
+        self.assertIn("present", errors[0])
+        self.assertIn("absent", errors[0])
+
+    def test_empty_string_value_is_treated_as_missing(self):
+        errors = validate_factors(factors(exposure=""))
+        self.assertEqual(len(errors), 1)
+        self.assertIn("factors.exposure", errors[0])
+
+    def test_multiple_bad_keys_produce_one_message_each(self):
+        errors = validate_factors(factors(exposure="offsite", data_class="health"))
+        self.assertEqual(len(errors), 2)
+
+    def test_compute_severity_raises_factor_error_on_invalid_input(self):
+        with self.assertRaises(FactorError):
+            compute_severity(factors(exposure="offsite"), "CONFIRMED")
+
+
+# ---------------------------------------------------------------------------
+# finding_store.normalise_finding: schema, hand-set severity, factors
+# ---------------------------------------------------------------------------
+
+class NormaliseFindingTests(unittest.TestCase):
+    def test_valid_finding_derives_severity_from_factors(self):
+        finding = normalise_finding(base_finding(), "security")
+        # internet(3) + pii(3) + multi-tenant(2) = 8 -> P0
+        self.assertEqual(finding["severity"], "P0")
+        self.assertEqual(finding["factors"], base_finding()["factors"])
+
+    def test_hand_set_severity_is_rejected(self):
+        with self.assertRaises(FindingError) as ctx:
+            normalise_finding(base_finding(severity="P0"), "security")
+        self.assertIn("severity", str(ctx.exception))
+
+    def test_missing_factors_is_rejected(self):
+        raw = base_finding()
+        del raw["factors"]
+        with self.assertRaises(FindingError) as ctx:
+            normalise_finding(raw, "security")
+        self.assertIn("factors", str(ctx.exception))
+
+    def test_invalid_factor_enum_is_rejected(self):
+        with self.assertRaises(FindingError) as ctx:
+            normalise_finding(base_finding(factors=factors(exposure="offsite")), "security")
+        self.assertIn("factors.exposure", str(ctx.exception))
+
+    def test_unverified_finding_is_capped_below_p0(self):
+        finding = normalise_finding(
+            base_finding(state="UNVERIFIED", resolve="check the cloud console"),
+            "security",
+        )
+        self.assertEqual(finding["severity"], "P1")
+
+    def test_load_lens_rejects_pre_derived_severity_schema(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "security.json"
+            write_json(path, {
+                "schema": 1,
+                "lens": "security",
+                "findings": [{**base_finding(), "severity": "P0", "factors": None}],
+            })
+            with self.assertRaises(FindingError) as ctx:
+                load_lens(path)
+            message = str(ctx.exception)
+            self.assertIn("schema", message)
+            self.assertIn("re-run", message.lower())
+
+    def test_load_lens_accepts_current_schema(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "security.json"
+            write_json(path, {"schema": FINDING_SCHEMA, "lens": "security",
+                               "findings": [base_finding()]})
+            findings = load_lens(path)
+            self.assertEqual(len(findings), 1)
+            self.assertEqual(findings[0]["severity"], "P0")
+
+
+# ---------------------------------------------------------------------------
+# validate_findings.validate(): the same rules, end to end
+# ---------------------------------------------------------------------------
+
+class ValidateFindingsIntegrationTests(unittest.TestCase):
+    def test_clean_finding_produces_no_errors(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [base_finding()])
+            errors, warnings, stats = validate(root)
+            self.assertEqual(errors, [])
+            self.assertEqual(stats["by_severity"].get("P0"), 1)
+
+    def test_hand_set_severity_is_a_named_error(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [base_finding(severity="P1")])
+            errors, _, _ = validate(root)
+            messages = [msg for _, _, msg in errors]
+            self.assertTrue(any("severity" in m and "must not be set" in m for m in messages))
+
+    def test_missing_factors_is_a_named_error(self):
+        with TempRoot() as root:
+            raw = base_finding()
+            del raw["factors"]
+            write_lens_file(root, "security", [raw])
+            errors, _, _ = validate(root)
+            messages = [msg for _, _, msg in errors]
+            self.assertTrue(any("factors" in m for m in messages))
+
+    def test_invalid_enum_value_names_offending_key_and_allowed_values(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [
+                base_finding(factors=factors(blast_radius="everywhere"))
+            ])
+            errors, _, _ = validate(root)
+            messages = [msg for _, _, msg in errors]
+            match = [m for m in messages if "factors.blast_radius" in m]
+            self.assertEqual(len(match), 1)
+            for value in ("systemic", "multi-tenant", "single-tenant", "single-user"):
+                self.assertIn(value, match[0])
+
+    def test_old_schema_file_fails_with_a_clear_message(self):
+        with TempRoot() as root:
+            path = root / ".readiness-audit" / "findings" / "security.json"
+            write_json(path, {
+                "schema": 1, "lens": "security",
+                "findings": [{**base_finding(), "severity": "P0"}],
+            })
+            errors, _, _ = validate(root)
+            messages = [msg for _, _, msg in errors]
+            self.assertTrue(any("schema" in m and "re-run" in m.lower() for m in messages))
+
+    def test_unverified_finding_reaching_p0_score_is_recorded_as_p1(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [
+                base_finding(
+                    state="UNVERIFIED",
+                    resolve="check the backup provider's console",
+                    factors=factors(exposure="internet", data_class="secrets",
+                                     blast_radius="systemic", compensating_control="absent"),
+                )
+            ])
+            errors, _, stats = validate(root)
+            self.assertEqual(stats["by_severity"].get("P0"), None)
+            self.assertEqual(stats["by_severity"].get("P1"), 1)
+
+
+# ---------------------------------------------------------------------------
+# compute_decision: all three outcomes
+# ---------------------------------------------------------------------------
+
+class ComputeDecisionTests(unittest.TestCase):
+    def test_no_findings_is_ship(self):
+        self.assertEqual(compute_decision([]), "SHIP")
+
+    def test_only_p2_and_p3_is_ship(self):
+        findings = [{"severity": "P2"}, {"severity": "P3"}]
+        self.assertEqual(compute_decision(findings), "SHIP")
+
+    def test_any_p1_with_no_p0_is_fix_then_ship(self):
+        findings = [{"severity": "P2"}, {"severity": "P1"}]
+        self.assertEqual(compute_decision(findings), "FIX_THEN_SHIP")
+
+    def test_any_p0_is_hold_even_alongside_p1(self):
+        findings = [{"severity": "P1"}, {"severity": "P0"}, {"severity": "P3"}]
+        self.assertEqual(compute_decision(findings), "HOLD")
+
+    def test_p0_outranks_everything(self):
+        findings = [{"severity": "P0"}]
+        self.assertEqual(compute_decision(findings), "HOLD")
+
+
+class ValidateFindingsDecisionCrossCheckTests(unittest.TestCase):
+    """verdict.json's decision, when present, must agree with the one
+    computed from the validated findings - disagreement is an error, not a
+    silent override."""
+
+    def test_agreeing_verdict_produces_no_decision_error(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [base_finding()])  # scores P0
+            write_verdict(root, "HOLD")
+            errors, _, _ = validate(root)
+            messages = [msg for _, _, msg in errors]
+            self.assertFalse(any("decision" in m for m in messages))
+
+    def test_disagreeing_verdict_is_a_validation_error(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [base_finding()])  # scores P0 -> HOLD
+            write_verdict(root, "SHIP")
+            errors, _, _ = validate(root)
+            messages = [msg for _, _, msg in errors]
+            match = [m for m in messages if "decision" in m]
+            self.assertEqual(len(match), 1)
+            self.assertIn("SHIP", match[0])
+            self.assertIn("HOLD", match[0])
+
+    def test_no_verdict_file_produces_no_decision_error(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [base_finding()])
+            errors, _, _ = validate(root)
+            messages = [msg for _, _, msg in errors]
+            self.assertFalse(any("decision" in m for m in messages))
+
+    def test_fix_then_ship_agreement(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [
+                base_finding(id="PRA-SEC-002",
+                             factors=factors(exposure="authenticated", data_class="business",
+                                              blast_radius="multi-tenant", compensating_control="absent"))
+            ])  # 2+1+2=5 -> P2, not enough for FIX_THEN_SHIP; use a P1 instead
+            write_lens_file(root, "backend", [
+                base_finding(id="PRA-BE-001", owner="backend",
+                             factors=factors(exposure="authenticated", data_class="financial",
+                                              blast_radius="single-tenant", compensating_control="absent"))
+            ])  # 2+3+1=6 -> P1
+            write_verdict(root, "FIX_THEN_SHIP")
+            errors, _, stats = validate(root)
+            messages = [msg for _, _, msg in errors]
+            self.assertFalse(any("decision" in m for m in messages))
+            self.assertIsNone(stats["by_severity"].get("P0"))
+            self.assertEqual(stats["by_severity"].get("P1"), 1)
+
+
+ASSEMBLE_SCRIPT = Path(__file__).parents[1] / "scripts" / "assemble_report.py"
+
+
+def run_assemble(root: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(ASSEMBLE_SCRIPT), str(root), *extra_args],
+        text=True, capture_output=True, check=False,
+    )
+
+
+class AssembleReportDecisionTests(unittest.TestCase):
+    """End to end: the report's decision line is computed from the findings,
+    never copied verbatim from verdict.json."""
+
+    def test_hold_is_rendered_for_a_p0_finding(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [base_finding()])  # scores P0
+            result = run_assemble(root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            report = (root / ".readiness-audit" / "report.md").read_text(encoding="utf-8")
+            self.assertIn("HOLD", report)
+
+    def test_ship_is_rendered_when_no_p0_or_p1_findings_exist(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [
+                base_finding(factors=factors(exposure="local", data_class="none",
+                                              blast_radius="single-user",
+                                              compensating_control="present"))
+            ])  # scores P3
+            result = run_assemble(root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            report = (root / ".readiness-audit" / "report.md").read_text(encoding="utf-8")
+            self.assertIn("**SHIP**", report)
+
+    def test_disagreeing_verdict_blocks_assembly_without_force(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [base_finding()])  # scores P0 -> HOLD
+            write_verdict(root, "SHIP")
+            result = run_assemble(root)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse((root / ".readiness-audit" / "report.md").exists())
+
+    def test_disagreeing_verdict_with_force_still_uses_the_computed_decision(self):
+        with TempRoot() as root:
+            write_lens_file(root, "security", [base_finding()])  # scores P0 -> HOLD
+            write_verdict(root, "SHIP")
+            result = run_assemble(root, "--force")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            report = (root / ".readiness-audit" / "report.md").read_text(encoding="utf-8")
+            self.assertIn("HOLD", report)
+            self.assertNotIn("**SHIP**", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

Four complaints, one root cause between the first and the last: the parts of this plugin that should have been mechanical were being performed by a language model.

1. **The dashboard started sometimes.** Launching it was advice to a model — run a background command, read the URL out of its output, best-effort open a browser. Advice gets skipped.
2. **The report could not leave the machine.** A local web page is not something you send to a reviewer.
3. **A running audit looked like a blank wall.** Lens status was inferred from whether a findings file existed yet, so seven agents working for several minutes produced no visible sign of life.
4. **Reviews were not reproducible.** Each lens chose its own P0–P3 severity, and the model wrote the go/no-go decision by hand — so the same repository could be graded differently on two runs.

## What changed

### Deterministic launch

The server re-spawns itself detached (`start_new_session` on POSIX, detached process flags on Windows), binds an ephemeral loopback port, and publishes its address atomically to `.readiness-audit/dashboard.json`. The launcher waits for that file, prints the URL, opens the browser from Python, and exits.

- **Reuse is decided by an HTTP health check** whose reported audit root must match — never by a recorded PID. Process identifiers are reused; a stale record is deleted, never used to signal a stranger's process.
- **A `PostToolUse` hook runs the same idempotent launcher** when audit state is written, so a skipped instruction no longer means no dashboard. The skill still runs it too, so the URL reaches the transcript; reuse makes the double invocation harmless by construction.
- **The server outlives the session**, because reviewers read the report after the audit ends. It closes after an hour without a reader, and an open tab keeps itself alive with a cheap ping — so a finished report is never closed out from under the person reading it. `--stop` closes it now.
- A corrupt or unknown-schema handshake file never blocks a launch. It is a cache; the running server is the source of truth.

### Derived severity and computed decision

A lens now supplies four closed enums — `exposure`, `data_class`, `blast_radius`, `compensating_control` — and a rubric derives P0–P3. UNVERIFIED findings are capped below P0, which encodes the existing invariant that uncertainty never escalates severity. The validator rejects a hand-set `severity` outright.

The decision is computed from the validated findings everywhere it appears, and shown only once the audit reaches its final stage so a running audit never claims SHIP. The model still writes `headline` and `summary`; an authored `decision` that disagrees with the findings is now a validation error rather than a silent override.

The finding schema is bumped to 2 with **no** compatibility shim — inferring factors from a previously authored severity would fabricate evidence-grade data, which is the exact failure this change exists to prevent. Old runs are archived, not migrated.

### Exportable reports

`scripts/export_report.py` generates from the same snapshot the dashboard renders, so an export cannot drift from what a reviewer saw. Each export writes to its own directory under `.readiness-audit/export/<git-ref>-<time>/` and nothing is overwritten, so "which version did they read" has an answer.

- `report.tex` — the full audit, including the evidence summary and an appendix of everything unverified.
- `report-<lens>.tex` ×7 — one per specialist, so a security engineer gets a document without the frontend findings.
- `report.md` — for anyone with no TeX toolchain.
- `report.pdf` — only when `tectonic` or `pdflatex` is present. Without one the command still succeeds and explains how to compile, because the zero-install principle holds.

Exporting a running audit is allowed, with a banner naming the stage reached and the lenses that have not reported. An incomplete audit that looks complete is the dangerous artifact.

LaTeX escaping is treated as correctness, not formatting: findings carry paths and code full of metacharacters, and a mangled file path in a security finding is worse than no finding.

### Live agent state

Each lens appends heartbeats to `.readiness-audit/progress/<lens>.jsonl` at five fixed checkpoints, through a bundled command that validates a closed phase vocabulary. One file per lens, append-only, because the lenses run in parallel and a shared mutable file would be a corruption bug.

The overview shows each specialist's phase and how long ago it reported, with an activity feed of what they said. **A silent lens renders as "no signal", never as progress** — a live view that invents activity is worse than one that admits it does not know.

## Deliberate trade-offs

- **The read-only observer principle is amended, not broken.** The export is the dashboard's only write. It produces derived documents under `.readiness-audit/export/` and can never start, stop, or alter an audit. This is stated explicitly in `PRODUCT.md` rather than left as a silent violation.
- **Earlier research argued against detaching the server**, on the grounds that a managed background task dies with the session. That is reversed here, and the reasoning is recorded: reviewers read reports after the session ends. Orphans are handled by health-check identity rules rather than by trusting a PID.
- **No backward compatibility for schema 1 findings.** Explained above; recorded in an ADR.

## Reviewer notes

- `CONTEXT.md` is new: it pins vocabulary this work needed, including *reviewer* meaning a lens rather than a human, and the distinction between an audit *stage* and a lens *phase*.
- Three ADRs record the decisions that are hard to reverse: derived severity, computed decision, and the detached dashboard.
- **156 tests pass** on the branch head. New coverage: handshake staleness and reuse against a stubbed health check, one real detached spawn that also proves reuse and stop, every rubric boundary and the UNVERIFIED cap, every LaTeX metacharacter, the incomplete-audit banner, per-lens document isolation, and the no-signal threshold.
- **Known gap:** the dashboard's JavaScript is covered only by string assertions against `DASHBOARD_HTML`. Nothing executes it. The activity feed, export button, and keepalive are verified server-side and structurally, not by a rendering run.
- The intermediate commits were not individually test-verified; the suite is green at the head of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
