### PR TITLE
Tell people when a newer release is waiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,23 @@ claude plugin list --json
 
 Use `@` directly in these commands. You do not need to type `\@`.
 
+### Update notices
+
+At the start of a session, the plugin compares its installed version against
+the `main` branch of
+[the upstream repository](https://github.com/Taimoorkhan1122/prod-readiness)
+and tells Claude when a newer release exists. Claude Code cannot swap a plugin
+out of a running session, so the notice is informational: update with
+`claude plugin update prod-readiness` and restart to apply it.
+
+The check runs at most once every 24 hours (the result is cached under
+`~/.cache/prod-readiness/update-check.json`), times out after 2 seconds, and
+fails silently — it never blocks or slows a session. To turn it off, set:
+
+```bash
+export PROD_READINESS_NO_UPDATE_CHECK=1
+```
+
 ## Use it on a project
 
 1. Open Claude Code in the folder for the app or website you want to check.
@@ -410,4 +427,5 @@ scripts/
   absence_probe.py
   validate_findings.py
   assemble_report.py
+  check_update.py
 ```

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Routes production-readiness requests into the staged audit workflow and starts the dashboard when an audit begins.",
+  "description": "Routes production-readiness requests into the staged audit workflow, starts the dashboard when an audit begins, and reports at session start when a newer plugin release is available.",
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -18,6 +18,16 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/launch_dashboard_hook.py\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/check_update.py\""
           }
         ]
       }

--- a/scripts/check_update.py
+++ b/scripts/check_update.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Notify at session start when a newer prod-readiness release is published.
+
+Claude Code cannot hot-swap a plugin inside a running session (`claude plugin
+update` requires a restart), so this hook only reports that an update exists.
+It never blocks the session: any failure, timeout, or malformed response exits
+quietly with status 0.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+UPSTREAM_MANIFEST_URL = (
+    "https://raw.githubusercontent.com/Taimoorkhan1122/prod-readiness"
+    "/main/.claude-plugin/plugin.json"
+)
+PLUGIN_NAME = "prod-readiness"
+CACHE_TTL_SECONDS = 24 * 60 * 60
+FETCH_TIMEOUT_SECONDS = 2.0
+OPT_OUT_ENV = "PROD_READINESS_NO_UPDATE_CHECK"
+
+VERSION_PART = re.compile(r"\d+")
+
+
+def cache_path() -> Path:
+    root = os.environ.get("XDG_CACHE_HOME")
+    base = Path(root) if root else Path.home() / ".cache"
+    return base / "prod-readiness" / "update-check.json"
+
+
+def plugin_root() -> Path:
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if root:
+        return Path(root)
+    return Path(__file__).resolve().parents[1]
+
+
+def read_local_version() -> str | None:
+    manifest = plugin_root() / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    version = data.get("version")
+    return version if isinstance(version, str) else None
+
+
+def read_cached_version(now: float) -> str | None:
+    try:
+        cached = json.loads(cache_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    checked_at = cached.get("checked_at")
+    version = cached.get("latest_version")
+    if not isinstance(checked_at, (int, float)) or not isinstance(version, str):
+        return None
+    if now - checked_at >= CACHE_TTL_SECONDS:
+        return None
+    return version
+
+
+def write_cache(version: str, now: float) -> None:
+    path = cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"checked_at": now, "latest_version": version}),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
+def fetch_upstream_version() -> str | None:
+    request = urllib.request.Request(
+        UPSTREAM_MANIFEST_URL,
+        headers={"User-Agent": f"{PLUGIN_NAME}-update-check"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+            payload = response.read(64_000).decode("utf-8")
+    except (urllib.error.URLError, OSError, ValueError, UnicodeDecodeError):
+        return None
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    version = data.get("version")
+    return version if isinstance(version, str) else None
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in VERSION_PART.findall(version)[:4])
+
+
+def is_newer(latest: str, local: str) -> bool:
+    latest_key, local_key = version_key(latest), version_key(local)
+    if not latest_key or not local_key:
+        return False
+    return latest_key > local_key
+
+
+def notice(local: str, latest: str) -> str:
+    return (
+        f"A newer {PLUGIN_NAME} release is available: {latest} (installed {local}). "
+        f"Tell the user they can update with `claude plugin update {PLUGIN_NAME}` "
+        "and restart Claude Code to apply it; the running session keeps using "
+        f"{local}. Mention this once, then continue with their request. "
+        f"They can silence this check by setting {OPT_OUT_ENV}=1."
+    )
+
+
+def main() -> int:
+    if os.environ.get(OPT_OUT_ENV, "").strip().lower() in {"1", "true", "yes"}:
+        return 0
+
+    local = read_local_version()
+    if local is None:
+        return 0
+
+    now = time.time()
+    latest = read_cached_version(now)
+    if latest is None:
+        latest = fetch_upstream_version()
+        if latest is None:
+            return 0
+        write_cache(latest, now)
+
+    if not is_newer(latest, local):
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": notice(local, latest),
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception:  # never break the session over an update check
+        raise SystemExit(0)

--- a/tests/test_check_update.py
+++ b/tests/test_check_update.py
@@ -1,0 +1,156 @@
+import json
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "check_update.py"
+
+
+def run_check(env_extra: dict, cache_dir: Path, plugin_root: Path):
+    env = {
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+        "HOME": str(cache_dir),
+        "XDG_CACHE_HOME": str(cache_dir),
+        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+        "PYTHONPATH": str(SCRIPT.parent),
+    }
+    env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def make_plugin_root(base: Path, version: str) -> Path:
+    root = base / "plugin"
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "prod-readiness", "version": version}), encoding="utf-8"
+    )
+    return root
+
+
+def write_cache(cache_dir: Path, version: str, age_seconds: float = 0.0) -> Path:
+    path = cache_dir / "prod-readiness" / "update-check.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"checked_at": time.time() - age_seconds, "latest_version": version}),
+        encoding="utf-8",
+    )
+    return path
+
+
+class CheckUpdateTests(unittest.TestCase):
+    def test_reports_when_cached_upstream_version_is_newer(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            root = make_plugin_root(base, "0.2.0")
+            write_cache(base, "0.3.0")
+
+            result = run_check({}, base, root)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            output = json.loads(result.stdout)
+            payload = output["hookSpecificOutput"]
+            self.assertEqual(payload["hookEventName"], "SessionStart")
+            self.assertIn("0.3.0", payload["additionalContext"])
+            self.assertIn("0.2.0", payload["additionalContext"])
+            self.assertIn("claude plugin update prod-readiness", payload["additionalContext"])
+
+    def test_stays_silent_when_versions_match(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            root = make_plugin_root(base, "0.2.0")
+            write_cache(base, "0.2.0")
+
+            result = run_check({}, base, root)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "")
+
+    def test_stays_silent_when_cached_version_is_older(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            root = make_plugin_root(base, "0.10.0")
+            write_cache(base, "0.9.9")
+
+            result = run_check({}, base, root)
+
+            self.assertEqual(result.stdout.strip(), "")
+
+    def test_opt_out_env_skips_the_check_entirely(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            root = make_plugin_root(base, "0.2.0")
+            write_cache(base, "9.9.9")
+
+            result = run_check({"PROD_READINESS_NO_UPDATE_CHECK": "1"}, base, root)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "")
+
+    def test_network_failure_is_silent(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            root = make_plugin_root(base, "0.2.0")
+            # No cache and an unroutable upstream: the fetch must fail quietly.
+            result = run_check(
+                {"http_proxy": "http://127.0.0.1:9", "https_proxy": "http://127.0.0.1:9"},
+                base,
+                root,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "")
+
+    def test_expired_cache_is_ignored(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            root = make_plugin_root(base, "0.2.0")
+            write_cache(base, "9.9.9", age_seconds=48 * 60 * 60)
+
+            result = run_check(
+                {"https_proxy": "http://127.0.0.1:9", "http_proxy": "http://127.0.0.1:9"},
+                base,
+                root,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "")
+
+    def test_missing_manifest_is_silent(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            root = base / "empty"
+            root.mkdir()
+            write_cache(base, "9.9.9")
+
+            result = run_check({}, base, root)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "")
+
+
+class HookRegistrationTests(unittest.TestCase):
+    def test_session_start_hook_is_registered(self):
+        hooks = json.loads(
+            (Path(__file__).parents[1] / "hooks" / "hooks.json").read_text(encoding="utf-8")
+        )
+        commands = [
+            hook["command"]
+            for entry in hooks["hooks"]["SessionStart"]
+            for hook in entry["hooks"]
+        ]
+        self.assertTrue(any("check_update.py" in command for command in commands))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The ask was for the plugin to self-update when invoked. Claude Code does not support that: plugin code is loaded at session start, and `claude plugin update` states outright that a restart is required to apply. There is no manifest field for auto-update, and the install records under `~/.claude/plugins/` are owned by Claude Code, not by the plugin.

So this does the achievable half — it makes sure nobody keeps running an old copy without knowing.

## What changed

- `scripts/check_update.py` — a `SessionStart` hook that compares the installed version in `.claude-plugin/plugin.json` against the same file on this repo's `main` branch. When upstream is newer, it emits `additionalContext` asking Claude to mention it once, with the update command and a note that the running session keeps using the old version until a restart.
- `hooks/hooks.json` — registers the hook.
- `README.md` — documents the notice, the cache, and how to turn it off.
- `tests/test_check_update.py` — covers newer / equal / older versions, opt-out, network failure, expired cache, missing manifest, and hook registration.

## Staying out of the way

An update check should never be the reason a session feels slow or breaks. This one:

- caches its result for 24 hours in `~/.cache/prod-readiness/update-check.json`, so at most one network call per day
- times out after 2 seconds
- exits 0 and prints nothing on any failure — network error, malformed JSON, missing manifest, or an unexpected exception
- is disabled entirely by `PROD_READINESS_NO_UPDATE_CHECK=1`

The check makes an outbound request to `raw.githubusercontent.com` at session start. It sends no repository or user data, only a `User-Agent`. It ships enabled by default; the opt-out env var is there for anyone who would rather it not reach the network at all.

## Verification

- `python3 -m unittest discover -s tests` — 164 tests pass (156 existing, 8 new).
- `claude plugin validate .` passes; the one warning about a missing marketplace description predates this branch.
- Ran the hook against the live upstream manifest: it read `0.2.0`, matched the installed `0.2.0`, printed nothing, and wrote the cache file.

Note for reviewers: running the suite under `pytest` fails at collection with `ModuleNotFoundError: No module named 'scripts'`. That is pre-existing and unrelated — CI runs `python -m unittest discover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)